### PR TITLE
Bossfight splits for late Dominion of Hate, disabled map check in Sin Odio end split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 [[package]]
 name = "asr"
 version = "0.1.0"
-source = "git+https://github.com/livesplit/asr#1acef2e8583417ff5b566dd583000daeb1a970a5"
+source = "git+https://github.com/livesplit/asr#5eb46194eccb3ae81791eb9bfba70e85029abed3"
 dependencies = [
  "arrayvec",
  "asr-derive",
@@ -24,18 +24,19 @@ dependencies = [
 [[package]]
 name = "asr-derive"
 version = "0.1.0"
-source = "git+https://github.com/livesplit/asr#1acef2e8583417ff5b566dd583000daeb1a970a5"
+source = "git+https://github.com/livesplit/asr#5eb46194eccb3ae81791eb9bfba70e85029abed3"
 dependencies = [
  "heck",
+ "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
@@ -45,18 +46,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
+checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -65,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
@@ -80,15 +81,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "live-a-live-autosplitter-wasm"
@@ -105,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -115,15 +116,21 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num_threads"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
@@ -178,18 +185,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -217,18 +224,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -237,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "simplelog"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
 dependencies = [
  "log",
  "termcolor",
@@ -263,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -274,22 +281,23 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
+ "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
@@ -305,10 +313,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -325,32 +334,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ A multiplatform autosplitter for Live a Live (PC)
 - Split on next chapter start (only when timer is running)
 
 # TODO:
-- [ ] Character Story Splits (will look more into this at a later time)
+- [~] Character Story Splits
+   - partially done in `revamp` branch, going through to get scenario ids
 - [ ] Full game ending splits
     - [ ] final boss end flash (this is going to be a nightmare)
-
+- [ ] TODO: Determine a better way to handle Present Day defeated enemies.
+  - intVars + in controller Face icons dont work for last enemy (since the game does this intentionally so you can reload the save)
+  - Maybe add a collective split when the odie kill animation starts.
+  - [ ] map id change for starting odie.
 
 ## Install
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,130 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717196966,
+        "narHash": "sha256-yZKhxVIKd2lsbOqYd5iDoUIwsRZFqE87smE2Vzf6Ck0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1706487304,
+        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1717442957,
+        "narHash": "sha256-w0fqHofxM2hf3pGDXCPSdH0A09v6FgHm6I38nCWA96k=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "025e1742de4fa75b3fb63818bd9726d17da6a102",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,9 +29,12 @@
           buildInputs = [
             pkg-config
             wasm-pack
+            rust-analyzer
+            rustfmt
             wasm-bindgen-cli
             (rust-bin.nightly.latest.default.override {
               targets = [ "wasm32-unknown-unknown" ];
+              extensions = ["rust-analyzer"];
             })
           ];
           LD_LIBRARY_PATH = libPath;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "Rust Flake Template";
+
+  inputs = {
+    nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url  = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        libPath = with pkgs; lib.makeLibraryPath [
+          # libGL
+          # libxkbcommon
+          # wayland
+          # xorg.libX11
+          # xorg.libXcursor
+          # xorg.libXi
+          # xorg.libXrandr
+        ];
+      in
+      {
+        devShells.default = with pkgs; mkShell {
+          buildInputs = [
+            pkg-config
+            wasm-pack
+            wasm-bindgen-cli
+            (rust-bin.nightly.latest.default.override {
+              targets = [ "wasm32-unknown-unknown" ];
+            })
+          ];
+          LD_LIBRARY_PATH = libPath;
+        };
+      }
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,8 @@ async fn main() {
                                 &mut splits,
                                 &current_chapter,
                                 &scenario_progress,
+                                &map_id,
+                                &transition_state,
                             );
                             
                             scenario_progress::wild_west::WildWest::maybe_split(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,8 @@ async fn main() {
                                 &mut splits,
                                 &current_chapter,
                                 &scenario_progress,
+                                &map_id,
+                                &transition_state,
                             );
 
                             scenario_progress::distant_future::DistantFuture::maybe_split(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,8 @@ async fn main() {
             GamePointer::<u16>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x1B8, 0x110, 0x1C0]);
         let mut loading_pointer =
             GamePointer::<u8>::new(main_module_base, vec![0x5092A98, 0x8, 0x10, 0x50, 0x30, 0x3FA]);
+        let mut transition_state_pointer =
+            GamePointer::<u32>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x0 + 0x38, 0x0, 0x70, 0x6C]);
         let mut chapter_data = ChapterData { character_data: vec![], map_id: GamePointer::<u32>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x378, 0x418]) };
         // asr::print_message("UPDATING");
         process
@@ -149,6 +151,9 @@ async fn main() {
                     let scenario_progress = scenario_progress_pointer.update_value(&process);
                     let map_id = chapter_data.map_id.update_value(&process);
 
+                    let transition_state = transition_state_pointer.update_value(&process);
+                        
+
                     chapter_data.update(&process, main_module_base);
 
                     // #[cfg(debug_assertions)]
@@ -156,6 +161,7 @@ async fn main() {
                         timer::set_variable_int("Current Chapter", current_chapter.current);
                         timer::set_variable_int("Scenario Progress", scenario_progress.current);
                         timer::set_variable_int("Map ID", map_id.current);
+                        timer::set_variable_int("Transition State", transition_state.current);
                         for (i, character) in chapter_data.character_data.clone().iter().enumerate() {
                             timer::set_variable_int(&format!("Character {} Level:", i), character.level);
                             timer::set_variable_int(&format!("Character {} Exp:", i), character.exp);
@@ -224,6 +230,8 @@ async fn main() {
                                 &mut splits,
                                 &current_chapter,
                                 &scenario_progress,
+                                &map_id,
+                                &transition_state,
                             );
 
                             scenario_progress::twilight_of_edo_japan::TwilightOfEdoJapan::maybe_split(
@@ -233,6 +241,7 @@ async fn main() {
                                 &scenario_progress,
                                 &chapter_data,
                                 &map_id,
+                                &transition_state,
                             );
 
                             scenario_progress::middle_ages::MiddleAges::maybe_split(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ use std::collections::HashSet;
 asr::async_main!(stable);
 
 struct ChapterData {
-  pub character_data: Vec<CharacterData>,
-  pub map_id: GamePointer<u32>,
+    pub character_data: Vec<CharacterData>,
+    pub map_id: GamePointer<u32>,
 }
 
 impl ChapterData {
@@ -28,10 +28,11 @@ impl ChapterData {
 
         let count_addr = vec![0x4A2DA88, 0x20, 0x1B8, 0x110, 0x158];
 
-        let count: Option<u8> = match process.read_pointer_path(module_base, asr::PointerSize::Bit64, &count_addr) {
-            Ok(val) => Some(val),
-            Err(_e) => Some(0),
-        };
+        let count: Option<u8> =
+            match process.read_pointer_path(module_base, asr::PointerSize::Bit64, &count_addr) {
+                Ok(val) => Some(val),
+                Err(_e) => Some(0),
+            };
 
         const SIZE: u64 = 0xB0;
 
@@ -40,11 +41,12 @@ impl ChapterData {
             let mut data_addr: Vec<u64> = vec![0x4A2DA88, 0x20, 0x1B8, 0x110, 0x150];
 
             data_addr.push(offset);
-            
-            let character_data_struct: Option<CharacterData> = match process.read_pointer_path(module_base, asr::PointerSize::Bit64,  &data_addr) {
-                Ok(val) => Some(val),
-                Err(_e) => None,
-            };
+
+            let character_data_struct: Option<CharacterData> =
+                match process.read_pointer_path(module_base, asr::PointerSize::Bit64, &data_addr) {
+                    Ok(val) => Some(val),
+                    Err(_e) => None,
+                };
             if let Some(val) = character_data_struct {
                 character_data.push(val);
             }
@@ -56,19 +58,18 @@ impl ChapterData {
 #[derive(bytemuck::CheckedBitPattern, Copy, Clone)]
 #[repr(C)]
 struct CharacterData {
-   _tag_name: u64,
-   level: u32,
-   max_hp: u32,
-   physical_attack: u32,
-   physical_defense: u32,
-   special_attack: u32,
-   special_defense: u32,
-   agility: u32,
-   accuracy: u32,
-   evasion: u32,
-   exp: u32
+    _tag_name: u64,
+    level: u32,
+    max_hp: u32,
+    physical_attack: u32,
+    physical_defense: u32,
+    special_attack: u32,
+    special_defense: u32,
+    agility: u32,
+    accuracy: u32,
+    evasion: u32,
+    exp: u32,
 }
-
 
 struct GamePointer<T: Clone> {
     pub address: Vec<u64>,
@@ -85,7 +86,11 @@ impl<T: Clone + bytemuck::Pod> GamePointer<T> {
         }
     }
     pub fn update_value(&mut self, process: &Process) -> Pair<T> {
-        let value: Option<T> = match process.read_pointer_path(self.module_base, asr::PointerSize::Bit64, &self.address) {
+        let value: Option<T> = match process.read_pointer_path(
+            self.module_base,
+            asr::PointerSize::Bit64,
+            &self.address,
+        ) {
             Ok(val) => Some(val),
             Err(_e) => Some(T::zeroed()),
         };
@@ -110,7 +115,7 @@ enum Chapter {
 async fn main() {
     let mut splits = HashSet::<String>::new();
     let mut settings = Settings::register();
-    
+
     loop {
         let process = match asr::get_os().ok().unwrap().as_str() {
             "linux" => Process::wait_attach("LIVEALIVE-Win64").await,
@@ -133,25 +138,74 @@ async fn main() {
             GamePointer::<u8>::new(main_module_base, vec![0x508ACE0, 0x10, 0xB0, 0xE0, 0x348]);
         let mut scenario_progress_pointer =
             GamePointer::<u16>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x1B8, 0x110, 0x1C0]);
-        let mut loading_pointer =
-            GamePointer::<u8>::new(main_module_base, vec![0x5092A98, 0x8, 0x10, 0x50, 0x30, 0x3FA]);
-        let mut transition_state_pointer =
-            GamePointer::<u32>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x0 + 0x38, 0x0, 0x70, 0x6C]);
+        let mut loading_pointer = GamePointer::<u8>::new(
+            main_module_base,
+            vec![0x5092A98, 0x8, 0x10, 0x50, 0x30, 0x3FA],
+        );
+        let mut transition_state_pointer = GamePointer::<u32>::new(
+            main_module_base,
+            vec![0x4A2DA88, 0x20, 0x0 + 0x38, 0x0, 0x70, 0x6C],
+        );
 
-        let mut present_day_namkiat_defeated_pointer =
-            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x318, 0x478]);
-        let mut present_day_aja_defeated_pointer =
-            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x320, 0x478]);
-        let mut present_day_tula_han_defeated_pointer =
-            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x328, 0x478]);
-        let mut present_day_moribe_defeated_pointer =
-            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x330, 0x478]);
-        let mut present_day_max_morgan_defeated_pointer =
-            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x338, 0x478]);
-        let mut present_day_jackie_defeated_pointer =
-            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x340, 0x478]);
+        let mut present_day_namkiat_defeated_pointer = GamePointer::<u8>::new(
+            main_module_base,
+            vec![
+                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x318, 0x478,
+            ],
+        );
+        let mut present_day_aja_defeated_pointer = GamePointer::<u8>::new(
+            main_module_base,
+            vec![
+                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x320, 0x478,
+            ],
+        );
+        let mut present_day_tula_han_defeated_pointer = GamePointer::<u8>::new(
+            main_module_base,
+            vec![
+                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x328, 0x478,
+            ],
+        );
+        let mut present_day_moribe_defeated_pointer = GamePointer::<u8>::new(
+            main_module_base,
+            vec![
+                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x330, 0x478,
+            ],
+        );
+        let mut present_day_max_morgan_defeated_pointer = GamePointer::<u8>::new(
+            main_module_base,
+            vec![
+                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x338, 0x478,
+            ],
+        );
+        let mut present_day_jackie_defeated_pointer = GamePointer::<u8>::new(
+            main_module_base,
+            vec![
+                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x340, 0x478,
+            ],
+        );
 
-        let mut chapter_data = ChapterData { character_data: vec![], map_id: GamePointer::<u32>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x378, 0x418]) };
+        let mut chapter_data = ChapterData {
+            character_data: vec![],
+            map_id: GamePointer::<u32>::new(
+                main_module_base,
+                vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x378, 0x418],
+            ),
+        };
+
+        // Frame number value for Sin Odio fight.
+        let mut last_known_position_frame_number_pointer = GamePointer::<u32>::new(
+            main_module_base,
+            vec![
+                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x338, 0x1B0, 0xF0, 0x250, 0x438,
+            ],
+        );
+        let mut last_known_position_duration_frames_pointer = GamePointer::<u32>::new(
+            main_module_base,
+            vec![
+                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x338, 0x1B0, 0xF0, 0x250, 0x2C4,
+            ],
+        );
+
         // asr::print_message("UPDATING");
         process
             .until_closes(async {
@@ -161,6 +215,9 @@ async fn main() {
                 let mut moribe_defeated = present_day_moribe_defeated_pointer.update_value(&process);
                 let mut max_morgan_defeated = present_day_max_morgan_defeated_pointer.update_value(&process);
                 let mut jackie_defeated = present_day_jackie_defeated_pointer.update_value(&process);
+
+                let mut frame_pointer_value = last_known_position_frame_number_pointer.update_value(&process);
+                let mut duration_frames_value = last_known_position_duration_frames_pointer.update_value(&process);
                 loop {
                     settings.update();
 
@@ -174,6 +231,14 @@ async fn main() {
                         
 
                     chapter_data.update(&process, main_module_base);
+                    
+                    // Sin odio fight completion
+                    if current_chapter.current == Chapter::DominionOfHate as u8 {
+                        frame_pointer_value = last_known_position_frame_number_pointer.update_value(&process);
+                        duration_frames_value = last_known_position_duration_frames_pointer.update_value(&process);
+                        timer::set_variable_int("FPV", frame_pointer_value.current);
+                        timer::set_variable_int("DF", duration_frames_value.current);
+                    }
 
                     if current_chapter.current == Chapter::PresentDay as u8 {
                         namkiat_defeated = present_day_namkiat_defeated_pointer.update_value(&process);
@@ -303,6 +368,9 @@ async fn main() {
                                 &mut splits,
                                 &current_chapter,
                                 &scenario_progress,
+                                &map_id,
+                                &frame_pointer_value,
+                                &duration_frames_value,
                             );
                             
                             if settings.load_removal {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,11 +137,33 @@ async fn main() {
             GamePointer::<u8>::new(main_module_base, vec![0x5092A98, 0x8, 0x10, 0x50, 0x30, 0x3FA]);
         let mut transition_state_pointer =
             GamePointer::<u32>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x0 + 0x38, 0x0, 0x70, 0x6C]);
+
+        // Cannot use these, as the last character never gets struck off
+        // let mut present_day_namkiat_defeated_pointer =
+        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x318, 0x478]);
+        // let mut present_day_aja_defeated_pointer =
+        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x320, 0x478]);
+        // let mut present_day_tula_han_defeated_pointer =
+        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x328, 0x478]);
+        // let mut present_day_moribe_defeated_pointer =
+        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x330, 0x478]);
+        // let mut present_day_max_morgan_defeated_pointer =
+        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x338, 0x478]);
+        // let mut present_day_jackie_defeated_pointer =
+        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x340, 0x478]);
+
         let mut chapter_data = ChapterData { character_data: vec![], map_id: GamePointer::<u32>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x378, 0x418]) };
         // asr::print_message("UPDATING");
         process
             .until_closes(async {
                 // TODO: Load some initial information from the process.
+                // cannot use these as the last character never gets struck off
+                // let mut namkiat_defeated = present_day_namkiat_defeated_pointer.update_value(&process);
+                // let mut aja_defeated = present_day_aja_defeated_pointer.update_value(&process);
+                // let mut tula_han_defeated = present_day_tula_han_defeated_pointer.update_value(&process);
+                // let mut moribe_defeated = present_day_moribe_defeated_pointer.update_value(&process);
+                // let mut max_morgan_defeated = present_day_max_morgan_defeated_pointer.update_value(&process);
+                // let mut jackie_defeated = present_day_jackie_defeated_pointer.update_value(&process);
                 loop {
                     settings.update();
 
@@ -155,6 +177,22 @@ async fn main() {
                         
 
                     chapter_data.update(&process, main_module_base);
+
+                    // if current_chapter.current == Chapter::PresentDay as u8 {
+                    //     namkiat_defeated = present_day_namkiat_defeated_pointer.update_value(&process);
+                    //     aja_defeated = present_day_aja_defeated_pointer.update_value(&process);
+                    //     tula_han_defeated = present_day_tula_han_defeated_pointer.update_value(&process);
+                    //     moribe_defeated = present_day_moribe_defeated_pointer.update_value(&process);
+                    //     max_morgan_defeated = present_day_max_morgan_defeated_pointer.update_value(&process);
+                    //     jackie_defeated = present_day_jackie_defeated_pointer.update_value(&process);
+                    //     timer::set_variable_int("Namkiat defeated", namkiat_defeated.current);
+                    //     timer::set_variable_int("Aja defeated", aja_defeated.current);
+                    //     timer::set_variable_int("Tula Han defeated", tula_han_defeated.current);
+                    //     timer::set_variable_int("Moribe defeated", moribe_defeated.current);
+                    //     timer::set_variable_int("Max Morgan defeated", max_morgan_defeated.current);
+                    //     timer::set_variable_int("Jackie defeated", jackie_defeated.current);
+
+                    // }
 
                     // #[cfg(debug_assertions)]
                     {
@@ -223,6 +261,14 @@ async fn main() {
                                 &mut splits,
                                 &current_chapter,
                                 &scenario_progress,
+                                &map_id,
+                                &transition_state,
+                                // &namkiat_defeated,
+                                // &aja_defeated,
+                                // &tula_han_defeated,
+                                // &moribe_defeated,
+                                // &max_morgan_defeated,
+                                // &jackie_defeated,
                             );
     
                             scenario_progress::near_future::NearFuture::maybe_split(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,32 +138,29 @@ async fn main() {
         let mut transition_state_pointer =
             GamePointer::<u32>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x0 + 0x38, 0x0, 0x70, 0x6C]);
 
-        // Cannot use these, as the last character never gets struck off
-        // let mut present_day_namkiat_defeated_pointer =
-        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x318, 0x478]);
-        // let mut present_day_aja_defeated_pointer =
-        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x320, 0x478]);
-        // let mut present_day_tula_han_defeated_pointer =
-        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x328, 0x478]);
-        // let mut present_day_moribe_defeated_pointer =
-        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x330, 0x478]);
-        // let mut present_day_max_morgan_defeated_pointer =
-        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x338, 0x478]);
-        // let mut present_day_jackie_defeated_pointer =
-        //     GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x340, 0x478]);
+        let mut present_day_namkiat_defeated_pointer =
+            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x318, 0x478]);
+        let mut present_day_aja_defeated_pointer =
+            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x320, 0x478]);
+        let mut present_day_tula_han_defeated_pointer =
+            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x328, 0x478]);
+        let mut present_day_moribe_defeated_pointer =
+            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x330, 0x478]);
+        let mut present_day_max_morgan_defeated_pointer =
+            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x338, 0x478]);
+        let mut present_day_jackie_defeated_pointer =
+            GamePointer::<u8>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x340, 0x478]);
 
         let mut chapter_data = ChapterData { character_data: vec![], map_id: GamePointer::<u32>::new(main_module_base, vec![0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x378, 0x418]) };
         // asr::print_message("UPDATING");
         process
             .until_closes(async {
-                // TODO: Load some initial information from the process.
-                // cannot use these as the last character never gets struck off
-                // let mut namkiat_defeated = present_day_namkiat_defeated_pointer.update_value(&process);
-                // let mut aja_defeated = present_day_aja_defeated_pointer.update_value(&process);
-                // let mut tula_han_defeated = present_day_tula_han_defeated_pointer.update_value(&process);
-                // let mut moribe_defeated = present_day_moribe_defeated_pointer.update_value(&process);
-                // let mut max_morgan_defeated = present_day_max_morgan_defeated_pointer.update_value(&process);
-                // let mut jackie_defeated = present_day_jackie_defeated_pointer.update_value(&process);
+                let mut namkiat_defeated = present_day_namkiat_defeated_pointer.update_value(&process);
+                let mut aja_defeated = present_day_aja_defeated_pointer.update_value(&process);
+                let mut tula_han_defeated = present_day_tula_han_defeated_pointer.update_value(&process);
+                let mut moribe_defeated = present_day_moribe_defeated_pointer.update_value(&process);
+                let mut max_morgan_defeated = present_day_max_morgan_defeated_pointer.update_value(&process);
+                let mut jackie_defeated = present_day_jackie_defeated_pointer.update_value(&process);
                 loop {
                     settings.update();
 
@@ -178,21 +175,21 @@ async fn main() {
 
                     chapter_data.update(&process, main_module_base);
 
-                    // if current_chapter.current == Chapter::PresentDay as u8 {
-                    //     namkiat_defeated = present_day_namkiat_defeated_pointer.update_value(&process);
-                    //     aja_defeated = present_day_aja_defeated_pointer.update_value(&process);
-                    //     tula_han_defeated = present_day_tula_han_defeated_pointer.update_value(&process);
-                    //     moribe_defeated = present_day_moribe_defeated_pointer.update_value(&process);
-                    //     max_morgan_defeated = present_day_max_morgan_defeated_pointer.update_value(&process);
-                    //     jackie_defeated = present_day_jackie_defeated_pointer.update_value(&process);
-                    //     timer::set_variable_int("Namkiat defeated", namkiat_defeated.current);
-                    //     timer::set_variable_int("Aja defeated", aja_defeated.current);
-                    //     timer::set_variable_int("Tula Han defeated", tula_han_defeated.current);
-                    //     timer::set_variable_int("Moribe defeated", moribe_defeated.current);
-                    //     timer::set_variable_int("Max Morgan defeated", max_morgan_defeated.current);
-                    //     timer::set_variable_int("Jackie defeated", jackie_defeated.current);
+                    if current_chapter.current == Chapter::PresentDay as u8 {
+                        namkiat_defeated = present_day_namkiat_defeated_pointer.update_value(&process);
+                        aja_defeated = present_day_aja_defeated_pointer.update_value(&process);
+                        tula_han_defeated = present_day_tula_han_defeated_pointer.update_value(&process);
+                        moribe_defeated = present_day_moribe_defeated_pointer.update_value(&process);
+                        max_morgan_defeated = present_day_max_morgan_defeated_pointer.update_value(&process);
+                        jackie_defeated = present_day_jackie_defeated_pointer.update_value(&process);
+                        timer::set_variable_int("Namkiat defeated", namkiat_defeated.current);
+                        timer::set_variable_int("Aja defeated", aja_defeated.current);
+                        timer::set_variable_int("Tula Han defeated", tula_han_defeated.current);
+                        timer::set_variable_int("Moribe defeated", moribe_defeated.current);
+                        timer::set_variable_int("Max Morgan defeated", max_morgan_defeated.current);
+                        timer::set_variable_int("Jackie defeated", jackie_defeated.current);
 
-                    // }
+                    }
 
                     // #[cfg(debug_assertions)]
                     {
@@ -263,12 +260,12 @@ async fn main() {
                                 &scenario_progress,
                                 &map_id,
                                 &transition_state,
-                                // &namkiat_defeated,
-                                // &aja_defeated,
-                                // &tula_han_defeated,
-                                // &moribe_defeated,
-                                // &max_morgan_defeated,
-                                // &jackie_defeated,
+                                &namkiat_defeated,
+                                &aja_defeated,
+                                &tula_han_defeated,
+                                &moribe_defeated,
+                                &max_morgan_defeated,
+                                &jackie_defeated,
                             );
     
                             scenario_progress::near_future::NearFuture::maybe_split(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,8 @@ async fn main() {
                                 &mut splits,
                                 &current_chapter,
                                 &scenario_progress,
+                                &map_id,
+                                &transition_state,
                             );
                             scenario_progress::present_day::PresentDay::maybe_split(
                                 &settings,

--- a/src/scenario_progress/distant_future.rs
+++ b/src/scenario_progress/distant_future.rs
@@ -1,0 +1,27 @@
+use std::collections::HashSet;
+
+use crate::settings::Settings;
+use crate::split;
+use crate::Chapter;
+use asr::watcher::Pair;
+
+pub struct DistantFuture;
+impl DistantFuture {
+    pub fn maybe_split(
+        settings: &Settings,
+        splits: &mut HashSet<String>,
+        current_chapter: &Pair<u8>,
+        _scenario_progress: &Pair<u16>,
+    ) {
+        // Start Split
+        if settings.start_middle_ages
+            && current_chapter.old == Chapter::Menu as u8
+            && current_chapter.current == Chapter::DistantFuture as u8
+        {
+            split(splits, "start_distant_future")
+        }
+        if current_chapter.current == Chapter::DistantFuture as u8 {
+            // Put Scenario Splits Here
+        }
+    }
+}

--- a/src/scenario_progress/distant_future.rs
+++ b/src/scenario_progress/distant_future.rs
@@ -14,7 +14,7 @@ impl DistantFuture {
         _scenario_progress: &Pair<u16>,
     ) {
         // Start Split
-        if settings.start_middle_ages
+        if settings.start_distant_future
             && current_chapter.old == Chapter::Menu as u8
             && current_chapter.current == Chapter::DistantFuture as u8
         {

--- a/src/scenario_progress/dominion_of_hate.rs
+++ b/src/scenario_progress/dominion_of_hate.rs
@@ -11,7 +11,10 @@ impl DominionOfHate {
         settings: &Settings,
         splits: &mut HashSet<String>,
         current_chapter: &Pair<u8>,
-        _scenario_progress: &Pair<u16>,
+        scenario_progress: &Pair<u16>,
+        map_id: &Pair<u32>,
+        frame_pointer_value: &Pair<u32>,
+        duration_frames_value: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_dominion_of_hate
@@ -22,6 +25,15 @@ impl DominionOfHate {
         }
         if current_chapter.current == Chapter::DominionOfHate as u8 {
             // Put Scenario Splits Here
+            if settings.split_on_sin_odio
+                && scenario_progress.current == 110
+                && map_id.current == 10237032
+                && duration_frames_value.current == 705
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_sin_odio")
+            }
         }
     }
 }

--- a/src/scenario_progress/dominion_of_hate.rs
+++ b/src/scenario_progress/dominion_of_hate.rs
@@ -1,0 +1,27 @@
+use std::collections::HashSet;
+
+use crate::settings::Settings;
+use crate::split;
+use crate::Chapter;
+use asr::watcher::Pair;
+
+pub struct DominionOfHate;
+impl DominionOfHate {
+    pub fn maybe_split(
+        settings: &Settings,
+        splits: &mut HashSet<String>,
+        current_chapter: &Pair<u8>,
+        _scenario_progress: &Pair<u16>,
+    ) {
+        // Start Split
+        if settings.start_dominion_of_hate
+            && current_chapter.old == Chapter::Menu as u8
+            && current_chapter.current == Chapter::DominionOfHate as u8
+        {
+            split(splits, "start_dominion_of_hate")
+        }
+        if current_chapter.current == Chapter::DominionOfHate as u8 {
+            // Put Scenario Splits Here
+        }
+    }
+}

--- a/src/scenario_progress/dominion_of_hate.rs
+++ b/src/scenario_progress/dominion_of_hate.rs
@@ -25,9 +25,47 @@ impl DominionOfHate {
         }
         if current_chapter.current == Chapter::DominionOfHate as u8 {
             // Put Scenario Splits Here
+            if settings.split_on_enter_odio
+                && scenario_progress.current == 60
+                && duration_frames_value.current == 212
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_enter_odio")
+            }
+            if settings.split_on_odio_face
+                && scenario_progress.current == 60
+                && duration_frames_value.current == 637
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_odio_face")
+            }
+            if settings.split_on_pure_odio
+                && scenario_progress.old == 60
+                && scenario_progress.current == 70
+            {
+                split(splits, "split_on_pure_odio")
+            }
+            if settings.split_on_sin_start
+                && scenario_progress.current == 110
+                && duration_frames_value.current == 270
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_sin_start")
+            }
+            if settings.split_on_sin_phase1
+                && scenario_progress.current == 110
+                && duration_frames_value.current == 330
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_sin_phase1")
+            }
             if settings.split_on_sin_odio
                 && scenario_progress.current == 110
-                && map_id.current == 10237032
+                //&& map_id.current == 10237032
                 && duration_frames_value.current == 705
                 && frame_pointer_value.old != 0
                 && frame_pointer_value.current < 60

--- a/src/scenario_progress/imperial_china.rs
+++ b/src/scenario_progress/imperial_china.rs
@@ -11,7 +11,9 @@ impl ImperialChina {
         settings: &Settings,
         splits: &mut HashSet<String>,
         current_chapter: &Pair<u8>,
-        _scenario_progress: &Pair<u16>,
+        scenario_progress: &Pair<u16>,
+        map_id: &Pair<u32>,
+        transition_state: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_imperial_china
@@ -22,6 +24,106 @@ impl ImperialChina {
         }
         if current_chapter.current == Chapter::ImperialChina as u8 {
             // Put Scenario Splits Here
+            //
+            if settings.imperial_china_recruit_all_disciples
+                && scenario_progress.old >= 50
+                && scenario_progress.old < 160
+                && scenario_progress.current == 160
+            {
+                split(splits, "imperial_china_recruit_all_diciples")
+            }
+            if settings.imperial_china_training_complete
+                && scenario_progress.old >= 300
+                && scenario_progress.old < 320
+                && scenario_progress.current == 320
+            {
+                split(splits, "imperial_china_training_complete")
+            }
+            if settings.imperial_china_defeat_sun_tzu_wang
+                && scenario_progress.old >= 390
+                && scenario_progress.old < 400
+                && scenario_progress.current == 400
+            {
+                split(splits, "imperial_china_defeat_sun_tzu_wang")
+            }
+            if settings.imperial_china_defeat_temple_guards
+                && scenario_progress.old >= 470
+                && scenario_progress.old < 490
+                && scenario_progress.current == 490
+            {
+                split(splits, "imperial_china_defeat_temple_guards")
+            }
+            if settings.imperial_china_defeat_courtyard_guards
+                && scenario_progress.old >= 490
+                && scenario_progress.old < 495
+                && scenario_progress.current == 495
+            {
+                split(splits, "imperial_china_defeat_courtyard_guards")
+            }
+            if settings.imperial_china_defeat_table_guards
+                && scenario_progress.old >= 510
+                && scenario_progress.old < 520
+                && scenario_progress.current == 520
+            {
+                split(splits, "imperial_china_defeat_table_guards")
+            }
+            if settings.imperial_china_defeat_su_xi_san_xi
+                && scenario_progress.old >= 521
+                && scenario_progress.old < 522
+                && scenario_progress.current == 522
+            {
+                split(splits, "imperial_china_defeat_su_xi_san_xi")
+            }
+            if settings.imperial_china_defeat_yi_xi_er_xi
+                && scenario_progress.old >= 522
+                && scenario_progress.old < 523
+                && scenario_progress.current == 523
+            {
+                split(splits, "imperial_china_defeat_yi_xi_er_xi")
+            }
+            if settings.imperial_china_defeat_tong_cha_sha_cha
+                && scenario_progress.old >= 523
+                && scenario_progress.old < 524
+                && scenario_progress.current == 524
+            {
+                split(splits, "imperial_china_defeat_tong_cha_sha_cha")
+            }
+            if settings.imperial_china_defeat_pei_cha_nan_cha
+                && scenario_progress.old >= 524
+                && scenario_progress.old < 530
+                && scenario_progress.current == 530
+            {
+                split(splits, "imperial_china_defeat_pei_cha_nan_cha")
+            }
+            if settings.imperial_china_defeat_xian_lin_chan
+                && scenario_progress.old >= 530
+                && scenario_progress.old < 531
+                && scenario_progress.current == 531
+            {
+                split(splits, "imperial_china_defeat_xian_lin_chan")
+            }
+            if settings.imperial_china_defeat_yi_pei_kou
+                && scenario_progress.old >= 531
+                && scenario_progress.old < 532
+                && scenario_progress.current == 532
+            {
+                split(splits, "imperial_china_defeat_yi_pei_kou")
+            }
+            if settings.imperial_china_defeat_ou_di_wan_li
+                && scenario_progress.old >= 533
+                && scenario_progress.old < 550
+                && scenario_progress.current == 550
+            {
+                split(splits, "imperial_china_defeat_yi_pei_kou")
+            }
+            if settings.imperial_china_end_split
+                && scenario_progress.current == 650
+                && map_id.current == 0
+                && transition_state.old == 4
+                && transition_state.current == 0
+            {
+                split(splits, "imperial_china_end_split")
+            }
         }
     }
 }

--- a/src/scenario_progress/imperial_china.rs
+++ b/src/scenario_progress/imperial_china.rs
@@ -14,7 +14,7 @@ impl ImperialChina {
         _scenario_progress: &Pair<u16>,
     ) {
         // Start Split
-        if settings.start_middle_ages
+        if settings.start_imperial_china
             && current_chapter.old == Chapter::Menu as u8
             && current_chapter.current == Chapter::ImperialChina as u8
         {

--- a/src/scenario_progress/imperial_china.rs
+++ b/src/scenario_progress/imperial_china.rs
@@ -1,0 +1,27 @@
+use std::collections::HashSet;
+
+use crate::settings::Settings;
+use crate::split;
+use crate::Chapter;
+use asr::watcher::Pair;
+
+pub struct ImperialChina;
+impl ImperialChina {
+    pub fn maybe_split(
+        settings: &Settings,
+        splits: &mut HashSet<String>,
+        current_chapter: &Pair<u8>,
+        _scenario_progress: &Pair<u16>,
+    ) {
+        // Start Split
+        if settings.start_middle_ages
+            && current_chapter.old == Chapter::Menu as u8
+            && current_chapter.current == Chapter::ImperialChina as u8
+        {
+            split(splits, "start_imperial_china")
+        }
+        if current_chapter.current == Chapter::ImperialChina as u8 {
+            // Put Scenario Splits Here
+        }
+    }
+}

--- a/src/scenario_progress/middle_ages.rs
+++ b/src/scenario_progress/middle_ages.rs
@@ -1,0 +1,27 @@
+use std::collections::HashSet;
+
+use crate::settings::Settings;
+use crate::split;
+use crate::Chapter;
+use asr::watcher::Pair;
+
+pub struct MiddleAges;
+impl MiddleAges {
+    pub fn maybe_split(
+        settings: &Settings,
+        splits: &mut HashSet<String>,
+        current_chapter: &Pair<u8>,
+        _scenario_progress: &Pair<u16>,
+    ) {
+        // Start Split
+        if settings.start_middle_ages
+            && current_chapter.old == Chapter::Menu as u8
+            && current_chapter.current == Chapter::MiddleAges as u8
+        {
+            split(splits, "start_middle_ages")
+        }
+        if current_chapter.current == Chapter::MiddleAges as u8 {
+            // Put Scenario Splits Here
+        }
+    }
+}

--- a/src/scenario_progress/mod.rs
+++ b/src/scenario_progress/mod.rs
@@ -1,4 +1,9 @@
+pub mod dominion_of_hate;
 pub mod middle_ages;
 pub mod near_future;
 pub mod twilight_of_edo_japan;
-pub mod dominion_of_hate;
+pub mod prehistory;
+pub mod distant_future;
+pub mod imperial_china;
+pub mod wild_west;
+pub mod present_day;

--- a/src/scenario_progress/mod.rs
+++ b/src/scenario_progress/mod.rs
@@ -1,0 +1,4 @@
+pub mod middle_ages;
+pub mod near_future;
+pub mod twilight_of_edo_japan;
+pub mod dominion_of_hate;

--- a/src/scenario_progress/mod.rs
+++ b/src/scenario_progress/mod.rs
@@ -1,9 +1,9 @@
+pub mod distant_future;
 pub mod dominion_of_hate;
+pub mod imperial_china;
 pub mod middle_ages;
 pub mod near_future;
-pub mod twilight_of_edo_japan;
 pub mod prehistory;
-pub mod distant_future;
-pub mod imperial_china;
-pub mod wild_west;
 pub mod present_day;
+pub mod twilight_of_edo_japan;
+pub mod wild_west;

--- a/src/scenario_progress/near_future.rs
+++ b/src/scenario_progress/near_future.rs
@@ -61,13 +61,6 @@ impl NearFuture {
             {
                 split(splits, "near_future_enter_titan_2")
             }
-            if settings.near_future_defeat_odeo
-                && scenario_progress.old == 760
-                && scenario_progress.current == 770
-            {
-                split(splits, "near_future_defeat_odeo")
-            }
-
             if settings.near_future_end_split
                 && scenario_progress.current == 900
                 && map_id.current == 0

--- a/src/scenario_progress/near_future.rs
+++ b/src/scenario_progress/near_future.rs
@@ -1,0 +1,63 @@
+use std::collections::HashSet;
+
+use crate::settings::Settings;
+use crate::split;
+use crate::Chapter;
+use asr::watcher::Pair;
+
+pub struct NearFuture;
+impl NearFuture {
+    pub fn maybe_split(
+        settings: &Settings,
+        splits: &mut HashSet<String>,
+        current_chapter: &Pair<u8>,
+        scenario_progress: &Pair<u16>,
+    ) {
+        // Start Split
+        if settings.start_near_future
+            && current_chapter.old == Chapter::Menu as u8
+            && current_chapter.current == Chapter::NearFuture as u8
+        {
+            split(splits, "start_near_future")
+        }
+
+        if current_chapter.current == Chapter::NearFuture as u8 {
+            if settings.near_future_park
+                && scenario_progress.old == 85
+                && scenario_progress.current == 110
+            {
+                split(splits, "near_future_park")
+            }
+            if settings.near_future_enter_titan
+                && scenario_progress.old == 270
+                && scenario_progress.current == 280
+            {
+                split(splits, "near_future_enter_titan")
+            }
+            if settings.near_future_dock
+                && scenario_progress.old == 380
+                && scenario_progress.current == 390
+            {
+                split(splits, "near_future_dock")
+            }
+            if settings.near_future_matsu_joins
+                && scenario_progress.old == 410
+                && scenario_progress.current == 450
+            {
+                split(splits, "near_future_matsu_joins")
+            }
+            if settings.near_future_robot
+                && scenario_progress.old == 460
+                && scenario_progress.current == 490
+            {
+                split(splits, "near_future_robot")
+            }
+            if settings.near_future_enter_titan_2
+                && scenario_progress.old == 670
+                && scenario_progress.current == 746
+            {
+                split(splits, "near_future_enter_titan_2")
+            }
+        }
+    }
+}

--- a/src/scenario_progress/near_future.rs
+++ b/src/scenario_progress/near_future.rs
@@ -12,6 +12,8 @@ impl NearFuture {
         splits: &mut HashSet<String>,
         current_chapter: &Pair<u8>,
         scenario_progress: &Pair<u16>,
+        map_id: &Pair<u32>,
+        transition_state: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_near_future
@@ -58,6 +60,21 @@ impl NearFuture {
                 && scenario_progress.current == 746
             {
                 split(splits, "near_future_enter_titan_2")
+            }
+            if settings.near_future_defeat_odeo
+                && scenario_progress.old == 760
+                && scenario_progress.current == 770
+            {
+                split(splits, "near_future_defeat_odeo")
+            }
+
+            if settings.near_future_end_split
+                && scenario_progress.current == 900
+                && map_id.current == 0
+                && transition_state.old == 4
+                && transition_state.current == 0
+            {
+                split(splits, "near_future_end_split")
             }
         }
     }

--- a/src/scenario_progress/near_future.rs
+++ b/src/scenario_progress/near_future.rs
@@ -45,7 +45,8 @@ impl NearFuture {
                 split(splits, "near_future_dock")
             }
             if settings.near_future_matsu_joins
-                && scenario_progress.old == 410
+                && scenario_progress.old >= 410
+                && scenario_progress.old < 450
                 && scenario_progress.current == 450
             {
                 split(splits, "near_future_matsu_joins")

--- a/src/scenario_progress/near_future.rs
+++ b/src/scenario_progress/near_future.rs
@@ -33,13 +33,15 @@ impl NearFuture {
                 split(splits, "near_future_park")
             }
             if settings.near_future_enter_titan
-                && scenario_progress.old == 270
+                && scenario_progress.old >= 270
+                && scenario_progress.old < 280
                 && scenario_progress.current == 280
             {
                 split(splits, "near_future_enter_titan")
             }
             if settings.near_future_dock
-                && scenario_progress.old == 380
+                && scenario_progress.old >= 380
+                && scenario_progress.old < 390
                 && scenario_progress.current == 390
             {
                 split(splits, "near_future_dock")
@@ -52,13 +54,15 @@ impl NearFuture {
                 split(splits, "near_future_matsu_joins")
             }
             if settings.near_future_robot
-                && scenario_progress.old == 460
+                && scenario_progress.old >= 460
+                && scenario_progress.old < 490
                 && scenario_progress.current == 490
             {
                 split(splits, "near_future_robot")
             }
             if settings.near_future_enter_titan_2
-                && scenario_progress.old == 670
+                && scenario_progress.old >= 670
+                && scenario_progress.old < 746
                 && scenario_progress.current == 746
             {
                 split(splits, "near_future_enter_titan_2")

--- a/src/scenario_progress/near_future.rs
+++ b/src/scenario_progress/near_future.rs
@@ -26,7 +26,8 @@ impl NearFuture {
         if current_chapter.current == Chapter::NearFuture as u8 {
             // Put Scenario Splits Here
             if settings.near_future_park
-                && scenario_progress.old == 85
+                && scenario_progress.old >= 85
+                && scenario_progress.old < 110
                 && scenario_progress.current == 110
             {
                 split(splits, "near_future_park")

--- a/src/scenario_progress/near_future.rs
+++ b/src/scenario_progress/near_future.rs
@@ -22,6 +22,7 @@ impl NearFuture {
         }
 
         if current_chapter.current == Chapter::NearFuture as u8 {
+            // Put Scenario Splits Here
             if settings.near_future_park
                 && scenario_progress.old == 85
                 && scenario_progress.current == 110

--- a/src/scenario_progress/prehistory.rs
+++ b/src/scenario_progress/prehistory.rs
@@ -1,0 +1,27 @@
+use std::collections::HashSet;
+
+use crate::settings::Settings;
+use crate::split;
+use crate::Chapter;
+use asr::watcher::Pair;
+
+pub struct Prehistory;
+impl Prehistory {
+    pub fn maybe_split(
+        settings: &Settings,
+        splits: &mut HashSet<String>,
+        current_chapter: &Pair<u8>,
+        _scenario_progress: &Pair<u16>,
+    ) {
+        // Start Split
+        if settings.start_middle_ages
+            && current_chapter.old == Chapter::Menu as u8
+            && current_chapter.current == Chapter::Prehistory as u8
+        {
+            split(splits, "start_prehistory")
+        }
+        if current_chapter.current == Chapter::Prehistory as u8 {
+            // Put Scenario Splits Here
+        }
+    }
+}

--- a/src/scenario_progress/prehistory.rs
+++ b/src/scenario_progress/prehistory.rs
@@ -24,19 +24,22 @@ impl Prehistory {
         }
         if current_chapter.current == Chapter::Prehistory as u8 {
             if settings.prehistory_turn_in_meat_to_elder
-                && scenario_progress.old == 70
+                && scenario_progress.old >= 70
+                && scenario_progress.old < 80
                 && scenario_progress.current == 80
             {
                 split(splits, "prehistory_turn_in_meat_to_elder")
             }
             if settings.prehistory_defeat_cavemen
-                && scenario_progress.old == 230
+                && scenario_progress.old >= 230
+                && scenario_progress.old < 240
                 && scenario_progress.current == 240
             {
                 split(splits, "prehistory_defeat_cavemen")
             }
             if settings.prehistory_defeat_zaki_1
-                && scenario_progress.old == 240
+                && scenario_progress.old >= 240
+                && scenario_progress.old < 250
                 && scenario_progress.current == 250
             {
                 split(splits, "prehistory_defeat_zaki_1")
@@ -56,7 +59,8 @@ impl Prehistory {
                 split(splits, "prehistory_defeat_zaki_3")
             }
             if settings.prehistory_defeat_odo
-                && scenario_progress.old == 405
+                && scenario_progress.old >= 405
+                && scenario_progress.old < 410
                 && scenario_progress.current == 410
             {
                 split(splits, "prehistory_defeat_odo")

--- a/src/scenario_progress/prehistory.rs
+++ b/src/scenario_progress/prehistory.rs
@@ -14,7 +14,7 @@ impl Prehistory {
         _scenario_progress: &Pair<u16>,
     ) {
         // Start Split
-        if settings.start_middle_ages
+        if settings.start_prehistory
             && current_chapter.old == Chapter::Menu as u8
             && current_chapter.current == Chapter::Prehistory as u8
         {

--- a/src/scenario_progress/prehistory.rs
+++ b/src/scenario_progress/prehistory.rs
@@ -45,14 +45,14 @@ impl Prehistory {
                 split(splits, "prehistory_defeat_zaki_1")
             }
             if settings.prehistory_defeat_zaki_2
-                && scenario_progress.old >= 285 
+                && scenario_progress.old >= 285
                 && scenario_progress.old < 291
                 && scenario_progress.current == 291
             {
                 split(splits, "prehistory_defeat_zaki_2")
             }
             if settings.prehistory_defeat_zaki_3
-                && scenario_progress.old >= 383 
+                && scenario_progress.old >= 383
                 && scenario_progress.old < 405
                 && scenario_progress.current == 405
             {

--- a/src/scenario_progress/prehistory.rs
+++ b/src/scenario_progress/prehistory.rs
@@ -11,7 +11,9 @@ impl Prehistory {
         settings: &Settings,
         splits: &mut HashSet<String>,
         current_chapter: &Pair<u8>,
-        _scenario_progress: &Pair<u16>,
+        scenario_progress: &Pair<u16>,
+        map_id: &Pair<u32>,
+        transition_state: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_prehistory
@@ -21,7 +23,52 @@ impl Prehistory {
             split(splits, "start_prehistory")
         }
         if current_chapter.current == Chapter::Prehistory as u8 {
-            // Put Scenario Splits Here
+            if settings.prehistory_turn_in_meat_to_elder
+                && scenario_progress.old == 70
+                && scenario_progress.current == 80
+            {
+                split(splits, "prehistory_turn_in_meat_to_elder")
+            }
+            if settings.prehistory_defeat_cavemen
+                && scenario_progress.old == 230
+                && scenario_progress.current == 240
+            {
+                split(splits, "prehistory_defeat_cavemen")
+            }
+            if settings.prehistory_defeat_zaki_1
+                && scenario_progress.old == 240
+                && scenario_progress.current == 250
+            {
+                split(splits, "prehistory_defeat_zaki_1")
+            }
+            if settings.prehistory_defeat_zaki_2
+                && scenario_progress.old >= 285 
+                && scenario_progress.old < 291
+                && scenario_progress.current == 291
+            {
+                split(splits, "prehistory_defeat_zaki_2")
+            }
+            if settings.prehistory_defeat_zaki_3
+                && scenario_progress.old >= 383 
+                && scenario_progress.old < 405
+                && scenario_progress.current == 405
+            {
+                split(splits, "prehistory_defeat_zaki_3")
+            }
+            if settings.prehistory_defeat_odo
+                && scenario_progress.old == 405
+                && scenario_progress.current == 410
+            {
+                split(splits, "prehistory_defeat_odo")
+            }
+            if settings.prehistory_end_split
+                && scenario_progress.current == 440
+                && map_id.current == 0
+                && transition_state.old == 4
+                && transition_state.current == 0
+            {
+                split(splits, "prehistory_end_split")
+            }
         }
     }
 }

--- a/src/scenario_progress/present_day.rs
+++ b/src/scenario_progress/present_day.rs
@@ -1,0 +1,27 @@
+use std::collections::HashSet;
+
+use crate::settings::Settings;
+use crate::split;
+use crate::Chapter;
+use asr::watcher::Pair;
+
+pub struct PresentDay;
+impl PresentDay {
+    pub fn maybe_split(
+        settings: &Settings,
+        splits: &mut HashSet<String>,
+        current_chapter: &Pair<u8>,
+        _scenario_progress: &Pair<u16>,
+    ) {
+        // Start Split
+        if settings.start_middle_ages
+            && current_chapter.old == Chapter::Menu as u8
+            && current_chapter.current == Chapter::PresentDay as u8
+        {
+            split(splits, "start_present_day")
+        }
+        if current_chapter.current == Chapter::PresentDay as u8 {
+            // Put Scenario Splits Here
+        }
+    }
+}

--- a/src/scenario_progress/present_day.rs
+++ b/src/scenario_progress/present_day.rs
@@ -14,16 +14,57 @@ impl PresentDay {
         scenario_progress: &Pair<u16>,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
+        namkiat_defeated: &Pair<u8>,
+        aja_defeated: &Pair<u8>,
+        tula_han_defeated: &Pair<u8>,
+        moribe_defeated: &Pair<u8>,
+        max_morgan_defeated: &Pair<u8>,
+        jackie_defeated: &Pair<u8>,
     ) {
         // Start Split
-        if settings.start_middle_ages
+        if settings.start_present_day
             && current_chapter.old == Chapter::Menu as u8
             && current_chapter.current == Chapter::PresentDay as u8
         {
             split(splits, "start_present_day")
         }
         if current_chapter.current == Chapter::PresentDay as u8 {
-            // Put Scenario Splits Here
+            if settings.present_day_moribe_defeated
+                && moribe_defeated.old == 0
+                && moribe_defeated.current == 1
+            {
+                split(splits, "present_day_moribe_defeated_split")
+            }
+            if settings.present_day_max_morgan_defeated
+                && max_morgan_defeated.old == 0
+                && max_morgan_defeated.current == 1
+            {
+                split(splits, "present_day_max_morgan_defeated_split")
+            }
+            if settings.present_day_jackie_defeated
+                && jackie_defeated.old == 0
+                && jackie_defeated.current == 1
+            {
+                split(splits, "present_day_jackie_defeated_split")
+            }
+            if settings.present_day_namkiat_defeated
+                && namkiat_defeated.old == 0
+                && namkiat_defeated.current == 1
+            {
+                split(splits, "present_day_namkiat_defeated_split")
+            }
+            if settings.present_day_aja_defeated
+                && aja_defeated.old == 0
+                && aja_defeated.current == 1
+            {
+                split(splits, "present_day_aja_defeated_split")
+            }
+            if settings.present_day_tula_han_defeated
+                && tula_han_defeated.old == 0
+                && tula_han_defeated.current == 1
+            {
+                split(splits, "present_day_tula_han_defeated_split")
+            }
             if settings.present_day_end_split
                 && scenario_progress.current == 0
                 && map_id.current == 0

--- a/src/scenario_progress/present_day.rs
+++ b/src/scenario_progress/present_day.rs
@@ -11,7 +11,9 @@ impl PresentDay {
         settings: &Settings,
         splits: &mut HashSet<String>,
         current_chapter: &Pair<u8>,
-        _scenario_progress: &Pair<u16>,
+        scenario_progress: &Pair<u16>,
+        map_id: &Pair<u32>,
+        transition_state: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_middle_ages
@@ -22,6 +24,14 @@ impl PresentDay {
         }
         if current_chapter.current == Chapter::PresentDay as u8 {
             // Put Scenario Splits Here
+            if settings.present_day_end_split
+                && scenario_progress.current == 0
+                && map_id.current == 0
+                && transition_state.old == 4
+                && transition_state.current == 0
+            {
+                split(splits, "present_day_end_split")
+            }
         }
     }
 }

--- a/src/scenario_progress/present_day.rs
+++ b/src/scenario_progress/present_day.rs
@@ -65,6 +65,12 @@ impl PresentDay {
             {
                 split(splits, "present_day_tula_han_defeated_split")
             }
+            if settings.present_day_start_odie
+                && map_id.old == 10228626
+                && map_id.current == 10228592
+            {
+                split(splits, "present_day_start_odie_split")
+            }
             if settings.present_day_end_split
                 && scenario_progress.current == 0
                 && map_id.current == 0

--- a/src/scenario_progress/twilight_of_edo_japan.rs
+++ b/src/scenario_progress/twilight_of_edo_japan.rs
@@ -39,7 +39,7 @@ impl TwilightOfEdoJapan {
             }
 
             if settings.twilight_defeat_gennai
-                && scenario_progress.old > 80
+                && scenario_progress.old >= 80
                 && scenario_progress.old < 120
                 && scenario_progress.current == 120
             {
@@ -64,7 +64,7 @@ impl TwilightOfEdoJapan {
             }
 
             if settings.twilight_defeat_monks
-                && scenario_progress.old > 130
+                && scenario_progress.old >= 130
                 && scenario_progress.old < 160
                 && scenario_progress.current == 160
             {

--- a/src/scenario_progress/twilight_of_edo_japan.rs
+++ b/src/scenario_progress/twilight_of_edo_japan.rs
@@ -20,6 +20,7 @@ impl TwilightOfEdoJapan {
         scenario_progress: &Pair<u16>,
         chapter_data: &ChapterData,
         map_id: &Pair<u32>,
+        transition_state: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_twilight_of_edo_japan
@@ -90,6 +91,15 @@ impl TwilightOfEdoJapan {
                 && scenario_progress.current == 200
             {
                 split(splits, "twilight_defeat_ode_iou")
+            }
+
+            if settings.twilight_end_split
+                && scenario_progress.current == 280
+                && map_id.current == 0
+                && transition_state.old == 4
+                && transition_state.current == 0
+            {
+                split(splits, "twilight_end_split")
             }
         }
     }

--- a/src/scenario_progress/twilight_of_edo_japan.rs
+++ b/src/scenario_progress/twilight_of_edo_japan.rs
@@ -1,0 +1,27 @@
+use std::collections::HashSet;
+
+use crate::settings::Settings;
+use crate::split;
+use crate::Chapter;
+use asr::watcher::Pair;
+
+pub struct TwilightOfEdoJapan;
+impl TwilightOfEdoJapan {
+    pub fn maybe_split(
+        settings: &Settings,
+        splits: &mut HashSet<String>,
+        current_chapter: &Pair<u8>,
+        _scenario_progress: &Pair<u16>,
+    ) {
+        // Start Split
+        if settings.start_twilight_of_edo_japan
+            && current_chapter.old == Chapter::Menu as u8
+            && current_chapter.current == Chapter::TwilightOfEdoJapan as u8
+        {
+            split(splits, "start_twilight_of_edo_japan")
+        }
+        if current_chapter.current == Chapter::TwilightOfEdoJapan as u8 {
+            // Put Scenario Splits Here
+        }
+    }
+}

--- a/src/scenario_progress/twilight_of_edo_japan.rs
+++ b/src/scenario_progress/twilight_of_edo_japan.rs
@@ -5,6 +5,11 @@ use crate::split;
 use crate::Chapter;
 use asr::watcher::Pair;
 
+
+// Locations
+// 10228295 - outside storehouse
+// 10228695 - Inside Storehouse
+
 pub struct TwilightOfEdoJapan;
 impl TwilightOfEdoJapan {
     pub fn maybe_split(

--- a/src/scenario_progress/twilight_of_edo_japan.rs
+++ b/src/scenario_progress/twilight_of_edo_japan.rs
@@ -33,7 +33,8 @@ impl TwilightOfEdoJapan {
             
             // Put Scenario Splits Here
             if settings.twilight_dodge_attic_ninja
-                && scenario_progress.old == 70
+                && scenario_progress.old >= 70
+                && scenario_progress.old < 80
                 && scenario_progress.current == 80
             {
                 split(splits, "twilight_dodge_attic_ninja")
@@ -73,21 +74,24 @@ impl TwilightOfEdoJapan {
             }
 
             if settings.twilight_defeat_musashi
-                && scenario_progress.old == 160
+                && scenario_progress.old >= 160
+                && scenario_progress.old < 170
                 && scenario_progress.current == 170
             {
                 split(splits, "twilight_defeat_musashi")
             }
             
             if settings.twilight_defeat_yodogimi
-                && scenario_progress.old == 180
+                && scenario_progress.old >= 180
+                && scenario_progress.old < 190
                 && scenario_progress.current == 190
             {
                 split(splits, "twilight_defeat_yodogimi")
             }
 
             if settings.twilight_defeat_ode_iou
-                && scenario_progress.old == 190
+                && scenario_progress.old >= 190
+                && scenario_progress.old < 200
                 && scenario_progress.current == 200
             {
                 split(splits, "twilight_defeat_ode_iou")

--- a/src/scenario_progress/twilight_of_edo_japan.rs
+++ b/src/scenario_progress/twilight_of_edo_japan.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use crate::settings::Settings;
 use crate::split;
 use crate::Chapter;
+use crate::ChapterData;
 use asr::watcher::Pair;
 
 
@@ -16,7 +17,9 @@ impl TwilightOfEdoJapan {
         settings: &Settings,
         splits: &mut HashSet<String>,
         current_chapter: &Pair<u8>,
-        _scenario_progress: &Pair<u16>,
+        scenario_progress: &Pair<u16>,
+        chapter_data: &ChapterData,
+        map_id: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_twilight_of_edo_japan
@@ -26,7 +29,68 @@ impl TwilightOfEdoJapan {
             split(splits, "start_twilight_of_edo_japan")
         }
         if current_chapter.current == Chapter::TwilightOfEdoJapan as u8 {
+            
             // Put Scenario Splits Here
+            if settings.twilight_dodge_attic_ninja
+                && scenario_progress.old == 70
+                && scenario_progress.current == 80
+            {
+                split(splits, "twilight_dodge_attic_ninja")
+            }
+
+            if settings.twilight_defeat_gennai
+                && scenario_progress.old > 80
+                && scenario_progress.old < 120
+                && scenario_progress.current == 120
+            {
+                split(splits, "twilight_defeat_gennai")
+            }
+
+            if settings.twilight_level_5_storehouse_leave
+                && map_id.old == 10228695
+                && map_id.current == 10228295
+                && chapter_data.character_data.clone().into_iter().nth(0).unwrap().level == 5
+                && chapter_data.character_data.clone().into_iter().nth(0).unwrap().exp >= 56
+            {
+                split(splits, "twilight_level_5_storehouse")
+            }
+            if settings.twilight_level_6_storehouse_leave
+                && map_id.old == 10228695
+                && map_id.current == 10228295
+                && chapter_data.character_data.clone().into_iter().nth(0).unwrap().level == 6
+                && scenario_progress.current == 120
+            {
+                split(splits, "twilight_level_6_storehouse")
+            }
+
+            if settings.twilight_defeat_monks
+                && scenario_progress.old > 130
+                && scenario_progress.old < 160
+                && scenario_progress.current == 160
+            {
+                split(splits, "twilight_defeat_monks")
+            }
+
+            if settings.twilight_defeat_musashi
+                && scenario_progress.old == 160
+                && scenario_progress.current == 170
+            {
+                split(splits, "twilight_defeat_musashi")
+            }
+            
+            if settings.twilight_defeat_yodogimi
+                && scenario_progress.old == 180
+                && scenario_progress.current == 190
+            {
+                split(splits, "twilight_defeat_yodogimi")
+            }
+
+            if settings.twilight_defeat_ode_iou
+                && scenario_progress.old == 190
+                && scenario_progress.current == 200
+            {
+                split(splits, "twilight_defeat_ode_iou")
+            }
         }
     }
 }

--- a/src/scenario_progress/twilight_of_edo_japan.rs
+++ b/src/scenario_progress/twilight_of_edo_japan.rs
@@ -6,7 +6,6 @@ use crate::Chapter;
 use crate::ChapterData;
 use asr::watcher::Pair;
 
-
 // Locations
 // 10228295 - outside storehouse
 // 10228695 - Inside Storehouse
@@ -30,7 +29,6 @@ impl TwilightOfEdoJapan {
             split(splits, "start_twilight_of_edo_japan")
         }
         if current_chapter.current == Chapter::TwilightOfEdoJapan as u8 {
-            
             // Put Scenario Splits Here
             if settings.twilight_dodge_attic_ninja
                 && scenario_progress.old >= 70
@@ -51,15 +49,36 @@ impl TwilightOfEdoJapan {
             if settings.twilight_level_5_storehouse_leave
                 && map_id.old == 10228695
                 && map_id.current == 10228295
-                && chapter_data.character_data.clone().into_iter().nth(0).unwrap().level == 5
-                && chapter_data.character_data.clone().into_iter().nth(0).unwrap().exp >= 56
+                && chapter_data
+                    .character_data
+                    .clone()
+                    .into_iter()
+                    .nth(0)
+                    .unwrap()
+                    .level
+                    == 5
+                && chapter_data
+                    .character_data
+                    .clone()
+                    .into_iter()
+                    .nth(0)
+                    .unwrap()
+                    .exp
+                    >= 56
             {
                 split(splits, "twilight_level_5_storehouse")
             }
             if settings.twilight_level_6_storehouse_leave
                 && map_id.old == 10228695
                 && map_id.current == 10228295
-                && chapter_data.character_data.clone().into_iter().nth(0).unwrap().level == 6
+                && chapter_data
+                    .character_data
+                    .clone()
+                    .into_iter()
+                    .nth(0)
+                    .unwrap()
+                    .level
+                    == 6
                 && scenario_progress.current == 120
             {
                 split(splits, "twilight_level_6_storehouse")
@@ -80,7 +99,7 @@ impl TwilightOfEdoJapan {
             {
                 split(splits, "twilight_defeat_musashi")
             }
-            
+
             if settings.twilight_defeat_yodogimi
                 && scenario_progress.old >= 180
                 && scenario_progress.old < 190

--- a/src/scenario_progress/wild_west.rs
+++ b/src/scenario_progress/wild_west.rs
@@ -11,7 +11,9 @@ impl WildWest {
         settings: &Settings,
         splits: &mut HashSet<String>,
         current_chapter: &Pair<u8>,
-        _scenario_progress: &Pair<u16>,
+        scenario_progress: &Pair<u16>,
+        map_id: &Pair<u32>,
+        transition_state: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_wild_west
@@ -21,7 +23,52 @@ impl WildWest {
             split(splits, "start_wild_west")
         }
         if current_chapter.current == Chapter::WildWest as u8 {
-            // Put Scenario Splits Here
+
+            if settings.wild_west_defeat_mad_dog_intro
+                && scenario_progress.old == 30
+                && scenario_progress.current == 40
+            {
+                split(splits, "wild_west_defeat_mad_dog_intro_split")
+            }
+            if settings.wild_west_defeat_defeat_pike
+                && scenario_progress.old == 60
+                && scenario_progress.current == 70
+            {
+                split(splits, "wild_west_defeat_pike_split")
+            }
+            if settings.wild_west_begin_ambush_phase
+                && scenario_progress.old == 90
+                && scenario_progress.current == 100
+            {
+                split(splits, "wild_west_begin_ambush_phase_split")
+            }
+            if settings.wild_west_end_ambush_phase
+                && scenario_progress.old >= 100
+                && scenario_progress.old < 180
+                && scenario_progress.current == 180
+            {
+                split(splits, "wild_west_end_ambush_phase_split")
+            }
+            if settings.wild_west_defeat_odie
+                && scenario_progress.old == 200
+                && scenario_progress.current == 210
+            {
+                split(splits, "wild_west_defeat_odie")
+            }
+            if settings.wild_west_mad_dog_final
+                && scenario_progress.old == 210
+                && scenario_progress.current == 220
+            {
+                split(splits, "wild_west_mad_dog_final")
+            }
+            if settings.wild_west_end_split
+                && scenario_progress.current == 250
+                && map_id.current == 0
+                && transition_state.old == 4
+                && transition_state.current == 0
+            {
+                split(splits, "wild_west_end_split")
+            }
         }
     }
 }

--- a/src/scenario_progress/wild_west.rs
+++ b/src/scenario_progress/wild_west.rs
@@ -14,7 +14,7 @@ impl WildWest {
         _scenario_progress: &Pair<u16>,
     ) {
         // Start Split
-        if settings.start_middle_ages
+        if settings.start_wild_west
             && current_chapter.old == Chapter::Menu as u8
             && current_chapter.current == Chapter::WildWest as u8
         {

--- a/src/scenario_progress/wild_west.rs
+++ b/src/scenario_progress/wild_west.rs
@@ -23,7 +23,6 @@ impl WildWest {
             split(splits, "start_wild_west")
         }
         if current_chapter.current == Chapter::WildWest as u8 {
-
             if settings.wild_west_defeat_mad_dog_intro
                 && scenario_progress.old == 30
                 && scenario_progress.current == 40

--- a/src/scenario_progress/wild_west.rs
+++ b/src/scenario_progress/wild_west.rs
@@ -1,0 +1,27 @@
+use std::collections::HashSet;
+
+use crate::settings::Settings;
+use crate::split;
+use crate::Chapter;
+use asr::watcher::Pair;
+
+pub struct WildWest;
+impl WildWest {
+    pub fn maybe_split(
+        settings: &Settings,
+        splits: &mut HashSet<String>,
+        current_chapter: &Pair<u8>,
+        _scenario_progress: &Pair<u16>,
+    ) {
+        // Start Split
+        if settings.start_middle_ages
+            && current_chapter.old == Chapter::Menu as u8
+            && current_chapter.current == Chapter::WildWest as u8
+        {
+            split(splits, "start_wild_west")
+        }
+        if current_chapter.current == Chapter::WildWest as u8 {
+            // Put Scenario Splits Here
+        }
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,10 +19,13 @@ pub struct Settings {
     pub load_removal: bool,
 
     start_settings: Title,
-    /// Automatic Start on Character Select
+    /// Start on Character Select (Single Story Start)
     pub start: bool,
     /// Automatic Start on New Game
     pub new_start: bool,
+
+    // Full Game Chapter Splits
+    full_game_run_chapter_splits: Title,
     /// Start/Split on Prehistory
     pub start_prehistory: bool,
     /// Start/Split on Distant Future

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -80,6 +80,8 @@ pub struct Settings {
     pub twilight_end_split: bool,
 
     present_day: Title,
+    #[heading_level = 2]
+    last_fight_before_odie_will_not_trigger: Title,
     // Present Day - Moribe Defeated
     pub present_day_moribe_defeated: bool,
     // Present Day - Max Morgan Defeated

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,5 @@
-use asr::settings::Gui;
 use asr::settings::gui::Title;
+use asr::settings::Gui;
 
 #[derive(Gui)]
 enum Category {
@@ -7,7 +7,7 @@ enum Category {
     SingleStory,
     /// Glitchless
     #[default]
-    TrueEnding
+    TrueEnding,
 }
 
 #[derive(Gui)]
@@ -23,6 +23,8 @@ pub struct Settings {
     pub start: bool,
     /// Automatic Start on New Game
     pub new_start: bool,
+    /// Split on Sin Odio Flash
+    pub split_on_sin_odio: bool,
 
     // Full Game Chapter Splits
     full_game_run_chapter_splits: Title,
@@ -106,31 +108,31 @@ pub struct Settings {
     /// Wild West - Intro - Defeat Mad Dog
     pub wild_west_defeat_mad_dog_intro: bool,
     /// Wild West - Defeat Pike
-    pub wild_west_defeat_defeat_pike: bool, 
+    pub wild_west_defeat_defeat_pike: bool,
     /// Wild West - Begin Ambush Phase
-    pub wild_west_begin_ambush_phase: bool, 
+    pub wild_west_begin_ambush_phase: bool,
     /// Wild West - End Ambush Phase
-    pub wild_west_end_ambush_phase: bool, 
+    pub wild_west_end_ambush_phase: bool,
     /// Wild West - Defeat Odie O'Bright
-    pub wild_west_defeat_odie: bool, 
+    pub wild_west_defeat_odie: bool,
     /// Wild West - Last Mad Dog Fight
-    pub wild_west_mad_dog_final: bool, 
+    pub wild_west_mad_dog_final: bool,
     /// Wild West - Chapter Complete
-    pub wild_west_end_split: bool, 
+    pub wild_west_end_split: bool,
 
     prehistory: Title,
     /// Prehistory - Turn in meat to elder
-    pub prehistory_turn_in_meat_to_elder: bool, 
+    pub prehistory_turn_in_meat_to_elder: bool,
     /// Prehistory - Defeat Cavemen
-    pub prehistory_defeat_cavemen: bool, 
+    pub prehistory_defeat_cavemen: bool,
     /// Prehistory - Defeat Zaki 1
-    pub prehistory_defeat_zaki_1: bool, 
+    pub prehistory_defeat_zaki_1: bool,
     /// Prehistory - Defeat Zaki 2
-    pub prehistory_defeat_zaki_2: bool, 
+    pub prehistory_defeat_zaki_2: bool,
     /// Prehistory - Defeat Zaki 3
-    pub prehistory_defeat_zaki_3: bool, 
+    pub prehistory_defeat_zaki_3: bool,
     /// Prehistory - Defeat Odo
-    pub prehistory_defeat_odo: bool, 
+    pub prehistory_defeat_odo: bool,
     /// Prehistory - Chapter Complete
-    pub prehistory_end_split: bool, 
+    pub prehistory_end_split: bool,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -61,7 +61,7 @@ pub struct Settings {
     twilight_of_edo_japan: Title,
     /// Edo Japan - After Dodging Attic Ninja
     pub twilight_dodge_attic_ninja: bool,
-    /// Edo Japan - Level 5 (>56xp) Storehouse Leave
+    /// Edo Japan - Level 5 (>=56xp) Storehouse Leave
     pub twilight_level_5_storehouse_leave: bool,
     /// Edo Japan - OR: Level 6 Storehouse Leave
     pub twilight_level_6_storehouse_leave: bool,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -78,4 +78,8 @@ pub struct Settings {
     pub twilight_defeat_ode_iou: bool,
     // Edo Japan - Chapter Complete
     pub twilight_end_split: bool,
+
+    present_day: Title,
+    // Present Day - Chapter Complete
+    pub present_day_end_split: bool,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -57,4 +57,23 @@ pub struct Settings {
     /// Near Future - Enter Steel Titan 2
     pub near_future_enter_titan_2: bool,
     // Near Future - Chapter Complete
+
+    twilight_of_edo_japan: Title,
+    /// Edo Japan - After Dodging Attic Ninja
+    pub twilight_dodge_attic_ninja: bool,
+    /// Edo Japan - Level 5 (>56xp) Storehouse Leave
+    pub twilight_level_5_storehouse_leave: bool,
+    /// Edo Japan - OR: Level 6 Storehouse Leave
+    pub twilight_level_6_storehouse_leave: bool,
+    /// Edo Japan - Defeat Gennai
+    pub twilight_defeat_gennai: bool,
+    /// Edo Japan - After Dialog in room after Monk Trio
+    pub twilight_defeat_monks: bool,
+    /// Edo Japan - Defeat Musashi
+    pub twilight_defeat_musashi: bool,
+    /// Edo Japan - Defeat Yodogimi
+    pub twilight_defeat_yodogimi: bool,
+    /// Edo Japan - Defeat Ode Iou (Human Form)
+    pub twilight_defeat_ode_iou: bool,
+    // Edo Japan - Chapter Complete
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -80,6 +80,20 @@ pub struct Settings {
     pub twilight_end_split: bool,
 
     present_day: Title,
+    // Present Day - Moribe Defeated
+    pub present_day_moribe_defeated: bool,
+    // Present Day - Max Morgan Defeated
+    pub present_day_max_morgan_defeated: bool,
+    // Present Day - Jackie Defeated
+    pub present_day_jackie_defeated: bool,
+    // Present Day - Namkiat Defeated
+    pub present_day_namkiat_defeated: bool,
+    // Present Day - Aja Defeated
+    pub present_day_aja_defeated: bool,
+    // Present Day - Tula Han Defeated
+    pub present_day_tula_han_defeated: bool,
+    // Present Day - Start Odie Fight
+    pub present_day_start_odie: bool,
     // Present Day - Chapter Complete
     pub present_day_end_split: bool,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -57,6 +57,7 @@ pub struct Settings {
     /// Near Future - Enter Steel Titan 2
     pub near_future_enter_titan_2: bool,
     // Near Future - Chapter Complete
+    pub near_future_end_split: bool,
 
     twilight_of_edo_japan: Title,
     /// Edo Japan - After Dodging Attic Ninja
@@ -76,4 +77,5 @@ pub struct Settings {
     /// Edo Japan - Defeat Ode Iou (Human Form)
     pub twilight_defeat_ode_iou: bool,
     // Edo Japan - Chapter Complete
+    pub twilight_end_split: bool,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,34 +1,49 @@
 use asr::settings::Gui;
+use asr::settings::gui::Title;
 
-#[derive(Debug, Gui)]
+#[derive(Gui)]
+enum Category {
+    /// Any%
+    SingleStory,
+    /// Glitchless
+    #[default]
+    TrueEnding
+}
+
+#[derive(Gui)]
 pub struct Settings {
-    #[default = true]
+    // Chapter Splits
+    load_settings: Title,
     /// Load Removal
+    #[default = true]
     pub load_removal: bool,
-    /// Automatic Start on character select
+
+    start_settings: Title,
+    /// Automatic Start on Character Select
     pub start: bool,
     /// Automatic Start on New Game
     pub new_start: bool,
-    /// Start Prehistory
+    /// Start/Split on Prehistory
     pub start_prehistory: bool,
-    /// Start Distant Future
+    /// Start/Split on Distant Future
     pub start_distant_future: bool,
-    /// Start Near Future
-    pub start_near_future: bool,
-    /// Start Wild West
+    /// Start/Split on Wild West
     pub start_wild_west: bool,
-    /// Start Present Day
+    /// Start/Split on Present Day
     pub start_present_day: bool,
-    /// Start Imperial China
+    /// Start/Split on Imperial China
     pub start_imperial_china: bool,
-    /// Start Twilight of Edo Japan
+    /// Start/Split on Twilight of Edo Japan
     pub start_twilight_of_edo_japan: bool,
-    /// Start Middle Ages
+    /// Start/Split on Middle Ages
     pub start_middle_ages: bool,
-    /// Start Dominion of Hate
+    /// Start/Split on Dominion of Hate
     pub start_dominion_of_hate: bool,
+    /// Start/Split on Near Future
+    pub start_near_future: bool,
 
     // Chapter Splits
+    near_future: Title,
     /// Near Future - Park
     pub near_future_park: bool,
     /// Near Future - Enter Steel Titan 1

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -114,4 +114,20 @@ pub struct Settings {
     pub wild_west_mad_dog_final: bool, 
     /// Wild West - Chapter Complete
     pub wild_west_end_split: bool, 
+
+    prehistory: Title,
+    /// Prehistory - Turn in meat to elder
+    pub prehistory_turn_in_meat_to_elder: bool, 
+    /// Prehistory - Defeat Cavemen
+    pub prehistory_defeat_cavemen: bool, 
+    /// Prehistory - Defeat Zaki 1
+    pub prehistory_defeat_zaki_1: bool, 
+    /// Prehistory - Defeat Zaki 2
+    pub prehistory_defeat_zaki_2: bool, 
+    /// Prehistory - Defeat Zaki 3
+    pub prehistory_defeat_zaki_3: bool, 
+    /// Prehistory - Defeat Odo
+    pub prehistory_defeat_odo: bool, 
+    /// Prehistory - Chapter Complete
+    pub prehistory_end_split: bool, 
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -135,4 +135,34 @@ pub struct Settings {
     pub prehistory_defeat_odo: bool,
     /// Prehistory - Chapter Complete
     pub prehistory_end_split: bool,
+
+    imperial_china: Title,
+    /// Imperial China - Recruit All Disciples
+    pub imperial_china_recruit_all_disciples: bool,
+    /// Imperial China - Training Complete
+    pub imperial_china_training_complete: bool,
+    /// Imperial China - Defeat Sun Tzu Wang
+    pub imperial_china_defeat_sun_tzu_wang: bool,
+    /// Imperial China - Defeat Temple Guards
+    pub imperial_china_defeat_temple_guards: bool,
+    /// Imperial China - Defeat Courtyard Guards
+    pub imperial_china_defeat_courtyard_guards: bool,
+    /// Imperial China - Defeat Table Guards
+    pub imperial_china_defeat_table_guards: bool,
+    /// Imperial China - G1 Defeat Su Xi / San Xi
+    pub imperial_china_defeat_su_xi_san_xi: bool,
+    /// Imperial China - G2 Defeat Yi Xi / Er Xi
+    pub imperial_china_defeat_yi_xi_er_xi: bool,
+    /// Imperial China - G3 Defeat Tong Cha / Sha Cha
+    pub imperial_china_defeat_tong_cha_sha_cha: bool,
+    /// Imperial China - G4 Defeat Pei Cha / Nan Cha
+    pub imperial_china_defeat_pei_cha_nan_cha: bool,
+    /// Imperial China - G5 Defeat Xian / Lin / Chan
+    pub imperial_china_defeat_xian_lin_chan: bool,
+    /// Imperial China - G6 Defeat Yi Pei Kou
+    pub imperial_china_defeat_yi_pei_kou: bool,
+    /// Imperial China - Defeat Ou Di Wan Li
+    pub imperial_china_defeat_ou_di_wan_li: bool,
+    /// Imperial China - Chapter Complete
+    pub imperial_china_end_split: bool,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -98,4 +98,20 @@ pub struct Settings {
     pub present_day_start_odie: bool,
     // Present Day - Chapter Complete
     pub present_day_end_split: bool,
+
+    wild_west: Title,
+    /// Wild West - Intro - Defeat Mad Dog
+    pub wild_west_defeat_mad_dog_intro: bool,
+    /// Wild West - Defeat Pike
+    pub wild_west_defeat_defeat_pike: bool, 
+    /// Wild West - Begin Ambush Phase
+    pub wild_west_begin_ambush_phase: bool, 
+    /// Wild West - End Ambush Phase
+    pub wild_west_end_ambush_phase: bool, 
+    /// Wild West - Defeat Odie O'Bright
+    pub wild_west_defeat_odie: bool, 
+    /// Wild West - Last Mad Dog Fight
+    pub wild_west_mad_dog_final: bool, 
+    /// Wild West - Chapter Complete
+    pub wild_west_end_split: bool, 
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -165,4 +165,16 @@ pub struct Settings {
     pub imperial_china_defeat_ou_di_wan_li: bool,
     /// Imperial China - Chapter Complete
     pub imperial_china_end_split: bool,
+
+    pub dominion_of_hate: Title,
+    /// Split on Odio Fight Start
+    pub split_on_enter_odio: bool,
+    /// Split on Pure Odio Transformation
+    pub split_on_odio_face: bool,
+    /// Split on Pure Odio Kill
+    pub split_on_pure_odio: bool,
+    /// Split on Sin Odio Start
+    pub split_on_sin_start: bool,
+    /// Split on Sin Odio Phase 1
+    pub split_on_sin_phase1: bool,
 }


### PR DESCRIPTION
I added the following splits under a new "Dominion of Hate" section: (Sin Odio Flash is currently still in Start Settings)
-Enter Odio fight (based on 212-frame animation duration at the start of the fight)
-Defeat Odio face (based on Pure Odio transformation animation [duration frames 637])
-Defeat Pure Odio (based on the update of Scenario Progress from 60 to 70 upon returning to the overworld)
-Enter Sin Odio fight (based on 270-frame animation at the start of the fight)
-End Sin Odio phase 1 (based on 330-frame animation)

I also commented out the map check in the Sin Odio Flash split, since map ID checks currently appear to be inconsistent across systems, and the Scenario Progress check should be enough to not need it