### PR TITLE
Added several splits for Dominion bossfights, hotfix for map ID incon…

### DIFF
--- a/src/scenario_progress/dominion_of_hate.rs
+++ b/src/scenario_progress/dominion_of_hate.rs
@@ -25,9 +25,47 @@ impl DominionOfHate {
         }
         if current_chapter.current == Chapter::DominionOfHate as u8 {
             // Put Scenario Splits Here
+            if settings.split_on_enter_odio
+                && scenario_progress.current == 60
+                && duration_frames_value.current == 212
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_enter_odio")
+            }
+            if settings.split_on_odio_face
+                && scenario_progress.current == 60
+                && duration_frames_value.current == 637
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_odio_face")
+            }
+            if settings.split_on_pure_odio
+                && scenario_progress.old == 60
+                && scenario_progress.current == 70
+            {
+                split(splits, "split_on_pure_odio")
+            }
+            if settings.split_on_sin_start
+                && scenario_progress.current == 110
+                && duration_frames_value.current == 270
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_sin_start")
+            }
+            if settings.split_on_sin_phase1
+                && scenario_progress.current == 110
+                && duration_frames_value.current == 330
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_sin_phase1")
+            }
             if settings.split_on_sin_odio
                 && scenario_progress.current == 110
-                && map_id.current == 10237032
+                //&& map_id.current == 10237032
                 && duration_frames_value.current == 705
                 && frame_pointer_value.old != 0
                 && frame_pointer_value.current < 60

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -165,4 +165,16 @@ pub struct Settings {
     pub imperial_china_defeat_ou_di_wan_li: bool,
     /// Imperial China - Chapter Complete
     pub imperial_china_end_split: bool,
+
+    pub dominion_of_hate: Title,
+    /// Split on Odio Fight Start
+    pub split_on_enter_odio: bool,
+    /// Split on Pure Odio Transformation
+    pub split_on_odio_face: bool,
+    /// Split on Pure Odio Kill
+    pub split_on_pure_odio: bool,
+    /// Split on Sin Odio Start
+    pub split_on_sin_start: bool,
+    /// Split on Sin Odio Phase 1
+    pub split_on_sin_phase1: bool,
 }


### PR DESCRIPTION
I added the following splits under a new "Dominion of Hate" section: (Sin Odio Flash is currently still in Start Settings)
-Enter Odio fight (based on 212-frame animation duration at the start of the fight)
-Defeat Odio face (based on Pure Odio transformation animation [duration frames 637])
-Defeat Pure Odio (based on the update of Scenario Progress from 60 to 70 upon returning to the overworld)
-Enter Sin Odio fight (based on 270-frame animation at the start of the fight)
-End Sin Odio phase 1 (based on 330-frame animation)

I also commented out the map check in the Sin Odio Flash split, since map ID checks currently appear to be inconsistent across systems, and the Scenario Progress check should be enough to not need it
