### PR TITLE
Added Middle Ages Splits and some more

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ A multiplatform autosplitter for Live a Live (PC)
 - [~] Character Story Splits
    - partially done in `revamp` branch, going through to get scenario ids
 - [ ] Full game ending splits
-    - [~] True Ending - Sin Odio end flash (this is the main and currently only speedrun category)
+    - [x] True Ending - Sin Odio end flash (this is the main and currently only official speedrun category)
     - [ ] Incomplete Destiny Ending - cutscene after completing partial boss rush
     - [ ] Never Ending - defeat Oersted? save prompt after completion? (a change in Scenario Progress after defeating Oersted is not guaranteed, particularly in the context of multi-ending runs like All Achievements)
-    - [ ] Sad Ending - skip cutscene after defeating all protagonists
-    - [ ] Armageddon (in Oersted route) - animation of activating the Armageddon action
+    - [x] Sad Ending - skip cutscene after defeating all protagonists
+    - [x] Armageddon (in Oersted route) - animation of activating the Armageddon action
 - [ ] TODO: Determine a better way to handle Present Day defeated enemies.
   - intVars + in controller Face icons dont work for last enemy (since the game does this intentionally so you can reload the save)
   - Maybe add a collective split when the odie kill animation starts.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ A multiplatform autosplitter for Live a Live (PC)
 - [~] Character Story Splits
    - partially done in `revamp` branch, going through to get scenario ids
 - [ ] Full game ending splits
-    - [ ] final boss end flash (this is going to be a nightmare)
+    - [~] True Ending - Sin Odio end flash (this is the main and currently only speedrun category)
+    - [ ] Incomplete Destiny Ending - cutscene after completing partial boss rush
+    - [ ] Never Ending - defeat Oersted? save prompt after completion? (a change in Scenario Progress after defeating Oersted is not guaranteed, particularly in the context of multi-ending runs like All Achievements)
+    - [ ] Sad Ending - skip cutscene after defeating all protagonists
+    - [ ] Armageddon (in Oersted route) - animation of activating the Armageddon action
 - [ ] TODO: Determine a better way to handle Present Day defeated enemies.
   - intVars + in controller Face icons dont work for last enemy (since the game does this intentionally so you can reload the save)
   - Maybe add a collective split when the odie kill animation starts.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,8 @@ async fn main() {
                                 &mut splits,
                                 &current_chapter,
                                 &scenario_progress,
+                                &map_id,
+                                &transition_state,
                             );
 
                             scenario_progress::dominion_of_hate::DominionOfHate::maybe_split(

--- a/src/scenario_progress/dominion_of_hate.rs
+++ b/src/scenario_progress/dominion_of_hate.rs
@@ -12,7 +12,7 @@ impl DominionOfHate {
         splits: &mut HashSet<String>,
         current_chapter: &Pair<u8>,
         scenario_progress: &Pair<u16>,
-        map_id: &Pair<u32>,
+        _map_id: &Pair<u32>,
         frame_pointer_value: &Pair<u32>,
         duration_frames_value: &Pair<u32>,
     ) {
@@ -25,43 +25,55 @@ impl DominionOfHate {
         }
         if current_chapter.current == Chapter::DominionOfHate as u8 {
             // Put Scenario Splits Here
-            if settings.split_on_enter_odio
+            if settings.dominion_start_not_oersted
+                && scenario_progress.old == 0
+                && scenario_progress.current == 30
+            {
+                split(splits, "dominion_start_not_oersted")
+            }
+            if settings.dominion_enter_roost
+                && scenario_progress.current == 40
+                && scenario_progress.old < 40
+            {
+                split(splits, "dominion_enter_roost")
+            }
+            if settings.dominion_enter_odio
                 && scenario_progress.current == 60
                 && duration_frames_value.current == 212
                 && frame_pointer_value.old != 0
                 && frame_pointer_value.current < 60
             {
-                split(splits, "split_on_enter_odio")
+                split(splits, "dominion_enter_odio")
             }
-            if settings.split_on_odio_face
+            if settings.dominion_defeat_odio_face
                 && scenario_progress.current == 60
                 && duration_frames_value.current == 637
                 && frame_pointer_value.old != 0
                 && frame_pointer_value.current < 60
             {
-                split(splits, "split_on_odio_face")
+                split(splits, "dominion_defeat_odio_face")
             }
-            if settings.split_on_pure_odio
-                && scenario_progress.old == 60
+            if settings.dominion_defeat_odio
                 && scenario_progress.current == 70
+                && scenario_progress.old < 70
             {
-                split(splits, "split_on_pure_odio")
+                split(splits, "dominion_defeat_odio")
             }
-            if settings.split_on_sin_start
+            if settings.dominion_enter_sin_fight
                 && scenario_progress.current == 110
                 && duration_frames_value.current == 270
                 && frame_pointer_value.old != 0
                 && frame_pointer_value.current < 60
             {
-                split(splits, "split_on_sin_start")
+                split(splits, "dominion_enter_sin_fight")
             }
-            if settings.split_on_sin_phase1
+            if settings.dominion_end_sin_phase1
                 && scenario_progress.current == 110
                 && duration_frames_value.current == 330
                 && frame_pointer_value.old != 0
                 && frame_pointer_value.current < 60
             {
-                split(splits, "split_on_sin_phase1")
+                split(splits, "dominion_end_sin_phase1")
             }
             if settings.split_on_sin_odio
                 && scenario_progress.current == 110
@@ -72,6 +84,34 @@ impl DominionOfHate {
             {
                 split(splits, "split_on_sin_odio")
             }
+            if settings.dominion_oersted_start
+                && scenario_progress.old == 0
+                && scenario_progress.current == 1000
+            {
+                split(splits, "dominion_oersted_start")
+            }
+            if settings.dominion_oersted_defeat_steel_titan
+                && scenario_progress.current == 1010
+                && duration_frames_value.current == 347
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "dominion_oersted_defeat_steel_titan")
+            }
+            if settings.dominion_oersted_armageddon
+                && scenario_progress.current == 1010
+                && duration_frames_value.current == 321
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "dominion_oersted_armageddon")
+            }
+            if settings.dominion_oersted_get_revenge 
+                && scenario_progress.current == 1020
+                && scenario_progress.old < 1020
+            {
+                split(splits, "dominion_oersted_get_revenge")
+            } 
         }
     }
 }

--- a/src/scenario_progress/dominion_of_hate.rs
+++ b/src/scenario_progress/dominion_of_hate.rs
@@ -25,9 +25,47 @@ impl DominionOfHate {
         }
         if current_chapter.current == Chapter::DominionOfHate as u8 {
             // Put Scenario Splits Here
+            if settings.split_on_enter_odio
+                && scenario_progress.current == 60
+                && duration_frames_value.current == 212
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_enter_odio")
+            }
+            if settings.split_on_odio_face
+                && scenario_progress.current == 60
+                && duration_frames_value.current == 637
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_odio_face")
+            }
+            if settings.split_on_pure_odio
+                && scenario_progress.old == 60
+                && scenario_progress.current == 70
+            {
+                split(splits, "split_on_pure_odio")
+            }
+            if settings.split_on_sin_start
+                && scenario_progress.current == 110
+                && duration_frames_value.current == 270
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_sin_start")
+            }
+            if settings.split_on_sin_phase1
+                && scenario_progress.current == 110
+                && duration_frames_value.current == 330
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "split_on_sin_phase1")
+            }
             if settings.split_on_sin_odio
                 && scenario_progress.current == 110
-                && map_id.current == 10237032
+                //&& map_id.current == 10237032
                 && duration_frames_value.current == 705
                 && frame_pointer_value.old != 0
                 && frame_pointer_value.current < 60

--- a/src/scenario_progress/middle_ages.rs
+++ b/src/scenario_progress/middle_ages.rs
@@ -11,7 +11,9 @@ impl MiddleAges {
         settings: &Settings,
         splits: &mut HashSet<String>,
         current_chapter: &Pair<u8>,
-        _scenario_progress: &Pair<u16>,
+        scenario_progress: &Pair<u16>,
+        map_id: &Pair<u32>,
+        transition_state: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_middle_ages
@@ -22,6 +24,62 @@ impl MiddleAges {
         }
         if current_chapter.current == Chapter::MiddleAges as u8 {
             // Put Scenario Splits Here
+            if settings.middle_ages_streibough_joins
+                && scenario_progress.current == 80
+                && scenario_progress.old < 80
+            {
+                split(splits, "middle_ages_streibough_joins")
+            }
+            if settings.middle_ages_brion
+                && scenario_progress.current == 140
+                && scenario_progress.old < 140
+            {
+                split(splits, "middle_ages_brion")
+            }
+            if settings.middle_ages_defeat_lord_of_dark
+                && scenario_progress.current == 160
+                && scenario_progress.old < 160
+            {
+                split(splits, "middle_ages_defeat_lord_of_dark")
+            }
+            if settings.middle_ages_banished
+                && scenario_progress.current == 250
+                && scenario_progress.old < 250
+            {
+                split(splits, "middle_ages_banished")
+            }
+            if settings.middle_ages_prison_escape
+                && scenario_progress.current == 360
+                && scenario_progress.old < 360
+            {
+                split(splits, "middle_ages_prison_escape")
+            }
+            if settings.middle_ages_defeat_claustrophobia
+                && scenario_progress.current == 370
+                && scenario_progress.old < 370
+            {
+                split(splits, "middle_ages_defeat_claustrophobia")
+            }
+            if settings.middle_ages_defeat_hygrophobia
+                && scenario_progress.current == 395
+                && scenario_progress.old < 395
+            {
+                split(splits, "middle_ages_defeat_hygrophobia")
+            }
+            if settings.middle_ages_defeat_streibough
+                && scenario_progress.current == 430
+                && scenario_progress.old < 430
+            {
+                split(splits, "middle_ages_defeat_streibough")
+            }
+            if settings.middle_ages_end_split
+                && scenario_progress.current == 510
+                && map_id.current == 0
+                && transition_state.old == 4
+                && transition_state.current == 0
+            {
+                split(splits, "middle_ages_end_split")
+            }
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -165,16 +165,51 @@ pub struct Settings {
     pub imperial_china_defeat_ou_di_wan_li: bool,
     /// Imperial China - Chapter Complete
     pub imperial_china_end_split: bool,
+    
+    middle_ages: Title,
+    /// Middle Ages - Exit Castle Town
+    pub middle_ages_streibough_joins: bool,
+    /// Middle Ages - Hasshe picks up Brion
+    pub middle_ages_brion: bool,
+    /// Middle Ages - Defeat The Lord of Dark
+    pub middle_ages_defeat_lord_of_dark: bool,
+    /// Middle Ages - Banished from Lucrece
+    pub middle_ages_banished: bool,
+    /// Middle Ages - Prison Escape
+    pub middle_ages_prison_escape: bool,
+    /// Middle Ages - Defeat Claustrophobia
+    pub middle_ages_defeat_claustrophobia: bool,
+    /// Middle Ages - Defeat Hygrophobia
+    pub middle_ages_defeat_hygrophobia: bool,
+    /// Middle Ages - Defeat Streibough
+    pub middle_ages_defeat_streibough: bool,
+    /// Middle Ages - Chapter Complete
+    pub middle_ages_end_split: bool,
 
-    pub dominion_of_hate: Title,
+    dominion_of_hate: Title,
+    /// Dominion of Hate - Start as non-Oersted protagonist
+    pub dominion_start_not_oersted: bool,
+    /// Dominion of Hate - Enter Archon's Roost
+    pub dominion_enter_roost: bool,
     /// Dominion of Hate - Enter Odio Fight
-    pub split_on_enter_odio: bool,
+    pub dominion_enter_odio: bool,
     /// Dominion of Hate - Defeat Odio Face
-    pub split_on_odio_face: bool,
+    pub dominion_defeat_odio_face: bool,
     ///Dominion of Hate - Defeat Pure Odio
-    pub split_on_pure_odio: bool,
+    pub dominion_defeat_odio: bool,
     /// Dominion of Hate - Enter Sin Odio
-    pub split_on_sin_start: bool,
+    pub dominion_enter_sin_fight: bool,
     /// Dominion of Hate - End Sin Odio Phase 1
-    pub split_on_sin_phase1: bool,
+    pub dominion_end_sin_phase1: bool,
+    
+    /// Dominion of Hate (Oersted)
+    dominion_of_hate_oersted: Title,
+    /// Dominion of Hate - Start as Oersted
+    pub dominion_oersted_start: bool,
+    /// Dominion of Hate (Oersted) - Split on defeating Steel Titan
+    pub dominion_oersted_defeat_steel_titan: bool,
+    /// Dominion of Hate (Oersted) - Split on Sad Ending
+    pub dominion_oersted_get_revenge: bool,
+    /// Dominion of Hate (Oersted) - Split on Armageddon Ending
+    pub dominion_oersted_armageddon: bool,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -167,14 +167,14 @@ pub struct Settings {
     pub imperial_china_end_split: bool,
 
     pub dominion_of_hate: Title,
-    /// Split on Odio Fight Start
+    /// Dominion of Hate - Enter Odio Fight
     pub split_on_enter_odio: bool,
-    /// Split on Pure Odio Transformation
+    /// Dominion of Hate - Defeat Odio Face
     pub split_on_odio_face: bool,
-    /// Split on Pure Odio Kill
+    ///Dominion of Hate - Defeat Pure Odio
     pub split_on_pure_odio: bool,
-    /// Split on Sin Odio Start
+    /// Dominion of Hate - Enter Sin Odio
     pub split_on_sin_start: bool,
-    /// Split on Sin Odio Phase 1
+    /// Dominion of Hate - End Sin Odio Phase 1
     pub split_on_sin_phase1: bool,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -165,4 +165,16 @@ pub struct Settings {
     pub imperial_china_defeat_ou_di_wan_li: bool,
     /// Imperial China - Chapter Complete
     pub imperial_china_end_split: bool,
+
+    pub dominion_of_hate: Title,
+    /// Split on Odio Fight Start
+    pub split_on_enter_odio: bool,
+    /// Split on Pure Odio Transformation
+    pub split_on_odio_face: bool,
+    /// Split on Pure Odio Kill
+    pub split_on_pure_odio: bool,
+    /// Split on Sin Odio Start
+    pub split_on_sin_start: bool,
+    /// Split on Sin Odio Phase 1
+    pub split_on_sin_phase1: bool,
 }


### PR DESCRIPTION
Added the following splits for Middle Ages:
-Leave Castle Town after Alethea is kidnapped
-Hasshe picks up Brion
-Defeat The Lord of Dark
-Get banished from Lucrece
-Escape after being arrested (triggers when the last scripted guards are defeated after leaving Castle Town
-Defeat Claustrophobia
-Defeat Hygrophobia
-Defeat Streibough
-End Chapter

Also renamed the recent Dominion of Hate splits to be more consistent with other chapters' splits, and added a few new ones related to the option to play as Oersted:
-Start the chapter as Oersted
-Start the chapter as a character other than Oersted
-Activate Armageddon as Oersted
-Defeat the Steel Titan as Oersted
-Complete the Sad Ending by defeating all 7 protagonists in Oersted's route