### PR TITLE
More Middle Ages splits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,6 @@ async fn main() {
                                 &scenario_progress,
                                 &map_id,
                                 &transition_state,
-                                &frame_pointer_value,
                                 &duration_frames_value,
                             );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,43 +147,6 @@ async fn main() {
             vec![0x4A2DA88, 0x20, 0x0 + 0x38, 0x0, 0x70, 0x6C],
         );
 
-        let mut present_day_namkiat_defeated_pointer = GamePointer::<u8>::new(
-            main_module_base,
-            vec![
-                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x318, 0x478,
-            ],
-        );
-        let mut present_day_aja_defeated_pointer = GamePointer::<u8>::new(
-            main_module_base,
-            vec![
-                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x320, 0x478,
-            ],
-        );
-        let mut present_day_tula_han_defeated_pointer = GamePointer::<u8>::new(
-            main_module_base,
-            vec![
-                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x328, 0x478,
-            ],
-        );
-        let mut present_day_moribe_defeated_pointer = GamePointer::<u8>::new(
-            main_module_base,
-            vec![
-                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x330, 0x478,
-            ],
-        );
-        let mut present_day_max_morgan_defeated_pointer = GamePointer::<u8>::new(
-            main_module_base,
-            vec![
-                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x338, 0x478,
-            ],
-        );
-        let mut present_day_jackie_defeated_pointer = GamePointer::<u8>::new(
-            main_module_base,
-            vec![
-                0x4A2DA88, 0x20, 0x20, 0x780, 0x78, 0x118, 0x3F8, 0x238, 0x430, 0x340, 0x478,
-            ],
-        );
-
         let mut chapter_data = ChapterData {
             character_data: vec![],
             map_id: GamePointer::<u32>::new(
@@ -209,12 +172,7 @@ async fn main() {
         // asr::print_message("UPDATING");
         process
             .until_closes(async {
-                let mut namkiat_defeated = present_day_namkiat_defeated_pointer.update_value(&process);
-                let mut aja_defeated = present_day_aja_defeated_pointer.update_value(&process);
-                let mut tula_han_defeated = present_day_tula_han_defeated_pointer.update_value(&process);
-                let mut moribe_defeated = present_day_moribe_defeated_pointer.update_value(&process);
-                let mut max_morgan_defeated = present_day_max_morgan_defeated_pointer.update_value(&process);
-                let mut jackie_defeated = present_day_jackie_defeated_pointer.update_value(&process);
+                let mut martial_artists_defeated = (0u8, 0u8);
                 loop {
                     settings.update();
 
@@ -233,19 +191,13 @@ async fn main() {
                     chapter_data.update(&process, main_module_base);
 
                     if current_chapter.current == Chapter::PresentDay as u8 {
-                        namkiat_defeated = present_day_namkiat_defeated_pointer.update_value(&process);
-                        aja_defeated = present_day_aja_defeated_pointer.update_value(&process);
-                        tula_han_defeated = present_day_tula_han_defeated_pointer.update_value(&process);
-                        moribe_defeated = present_day_moribe_defeated_pointer.update_value(&process);
-                        max_morgan_defeated = present_day_max_morgan_defeated_pointer.update_value(&process);
-                        jackie_defeated = present_day_jackie_defeated_pointer.update_value(&process);
-                        timer::set_variable_int("Namkiat defeated", namkiat_defeated.current);
-                        timer::set_variable_int("Aja defeated", aja_defeated.current);
-                        timer::set_variable_int("Tula Han defeated", tula_han_defeated.current);
-                        timer::set_variable_int("Moribe defeated", moribe_defeated.current);
-                        timer::set_variable_int("Max Morgan defeated", max_morgan_defeated.current);
-                        timer::set_variable_int("Jackie defeated", jackie_defeated.current);
-
+                        if duration_frames_value.current == 180 &&
+                            duration_frames_value.old == 0 
+                        {
+                            martial_artists_defeated.1 = martial_artists_defeated.0;
+                            martial_artists_defeated.0 += 1u8;
+                        }
+                        timer::set_variable_int("Martial artists defeated", martial_artists_defeated.0)
                     }
 
                     // #[cfg(debug_assertions)]
@@ -269,6 +221,7 @@ async fn main() {
                                 && current_chapter.current != Chapter::Menu as u8
                             {
                                 // asr::print_message("Clearing Splits and Starting");
+                                martial_artists_defeated = (0u8,0u8);
                                 splits = HashSet::<String>::new();
                                 timer::start();
                             }
@@ -278,6 +231,7 @@ async fn main() {
                                 && new_game_start.current > 0
                             {
                                 // asr::print_message("Clearing Splits and Starting");
+                                martial_artists_defeated = (0u8,0u8);
                                 splits = HashSet::<String>::new();
                                 timer::start();
                             }
@@ -325,12 +279,8 @@ async fn main() {
                                 &scenario_progress,
                                 &map_id,
                                 &transition_state,
-                                &namkiat_defeated,
-                                &aja_defeated,
-                                &tula_han_defeated,
-                                &moribe_defeated,
-                                &max_morgan_defeated,
-                                &jackie_defeated,
+                                martial_artists_defeated,
+                                &duration_frames_value,
                             );
     
                             scenario_progress::near_future::NearFuture::maybe_split(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,14 +231,6 @@ async fn main() {
                         
 
                     chapter_data.update(&process, main_module_base);
-                    
-                    // Sin odio fight completion
-                    if current_chapter.current == Chapter::DominionOfHate as u8 {
-                        frame_pointer_value = last_known_position_frame_number_pointer.update_value(&process);
-                        duration_frames_value = last_known_position_duration_frames_pointer.update_value(&process);
-                        timer::set_variable_int("FPV", frame_pointer_value.current);
-                        timer::set_variable_int("DF", duration_frames_value.current);
-                    }
 
                     if current_chapter.current == Chapter::PresentDay as u8 {
                         namkiat_defeated = present_day_namkiat_defeated_pointer.update_value(&process);
@@ -262,6 +254,8 @@ async fn main() {
                         timer::set_variable_int("Scenario Progress", scenario_progress.current);
                         timer::set_variable_int("Map ID", map_id.current);
                         timer::set_variable_int("Transition State", transition_state.current);
+                        timer::set_variable_int("FPV", frame_pointer_value.current);
+                        timer::set_variable_int("DF", duration_frames_value.current);
                         for (i, character) in chapter_data.character_data.clone().iter().enumerate() {
                             timer::set_variable_int(&format!("Character {} Level:", i), character.level);
                             timer::set_variable_int(&format!("Character {} Exp:", i), character.exp);
@@ -365,6 +359,8 @@ async fn main() {
                                 &scenario_progress,
                                 &map_id,
                                 &transition_state,
+                                &frame_pointer_value,
+                                &duration_frames_value,
                             );
 
                             scenario_progress::dominion_of_hate::DominionOfHate::maybe_split(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,9 +215,6 @@ async fn main() {
                 let mut moribe_defeated = present_day_moribe_defeated_pointer.update_value(&process);
                 let mut max_morgan_defeated = present_day_max_morgan_defeated_pointer.update_value(&process);
                 let mut jackie_defeated = present_day_jackie_defeated_pointer.update_value(&process);
-
-                let mut frame_pointer_value = last_known_position_frame_number_pointer.update_value(&process);
-                let mut duration_frames_value = last_known_position_duration_frames_pointer.update_value(&process);
                 loop {
                     settings.update();
 
@@ -228,6 +225,9 @@ async fn main() {
                     let map_id = chapter_data.map_id.update_value(&process);
 
                     let transition_state = transition_state_pointer.update_value(&process);
+
+                    let frame_pointer_value = last_known_position_frame_number_pointer.update_value(&process);
+                    let duration_frames_value = last_known_position_duration_frames_pointer.update_value(&process);
                         
 
                     chapter_data.update(&process, main_module_base);

--- a/src/scenario_progress/dominion_of_hate.rs
+++ b/src/scenario_progress/dominion_of_hate.rs
@@ -40,24 +40,21 @@ impl DominionOfHate {
             if settings.dominion_enter_odio
                 && scenario_progress.current == 60
                 && duration_frames_value.current == 212
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "dominion_enter_odio")
             }
             if settings.dominion_defeat_odio_face
                 && scenario_progress.current == 60
                 && duration_frames_value.current == 637
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "dominion_defeat_odio_face")
             }
             if settings.dominion_defeat_pure_odio
                 && scenario_progress.current == 60
                 && duration_frames_value.current == 368
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "dominion_defeat_pure_odio")
             }
@@ -70,22 +67,19 @@ impl DominionOfHate {
             if settings.dominion_enter_sin_fight
                 && scenario_progress.current == 110
                 && duration_frames_value.current == 270
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "dominion_enter_sin_fight")
             }
             if settings.dominion_end_sin_phase1
                 && scenario_progress.current == 110
                 && duration_frames_value.current == 330
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "dominion_end_sin_phase1")
             }
             if settings.split_on_sin_odio
                 && scenario_progress.current == 110
-                //&& map_id.current == 10237032
                 && duration_frames_value.current == 705
                 && frame_pointer_value.old != 0
                 && frame_pointer_value.current < 60
@@ -101,16 +95,14 @@ impl DominionOfHate {
             if settings.dominion_oersted_defeat_steel_titan
                 && scenario_progress.current == 1010
                 && duration_frames_value.current == 347
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "dominion_oersted_defeat_steel_titan")
             }
             if settings.dominion_oersted_armageddon
                 && scenario_progress.current == 1010
                 && duration_frames_value.current == 321
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "dominion_oersted_armageddon")
             }

--- a/src/scenario_progress/dominion_of_hate.rs
+++ b/src/scenario_progress/dominion_of_hate.rs
@@ -53,11 +53,19 @@ impl DominionOfHate {
             {
                 split(splits, "dominion_defeat_odio_face")
             }
-            if settings.dominion_defeat_odio
-                && scenario_progress.current == 70
-                && scenario_progress.old < 70
+            if settings.dominion_defeat_pure_odio
+                && scenario_progress.current == 60
+                && duration_frames_value.current == 368
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
             {
-                split(splits, "dominion_defeat_odio")
+                split(splits, "dominion_defeat_pure_odio")
+            }
+            if settings.dominion_defeat_odio_fade
+                && scenario_progress.old < 70
+                && scenario_progress.current == 70
+            {
+                split(splits, "dominion_defeat_odio_fade")
             }
             if settings.dominion_enter_sin_fight
                 && scenario_progress.current == 110

--- a/src/scenario_progress/middle_ages.rs
+++ b/src/scenario_progress/middle_ages.rs
@@ -14,7 +14,6 @@ impl MiddleAges {
         scenario_progress: &Pair<u16>,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
-        frame_pointer_value: &Pair<u32>,
         duration_frames_value: &Pair<u32>,
     ) {
         // Start Split
@@ -53,16 +52,14 @@ impl MiddleAges {
             if settings.middle_ages_archons_roost_1
                 && scenario_progress.current == 150
                 && duration_frames_value.current == 122
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "middle_ages_archons_roost_1")
             }
             if settings.middle_ages_defeat_lord_of_dark
                 && scenario_progress.current == 150
                 && duration_frames_value.current == 347
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "middle_ages_defeat_lord_of_dark")
             }
@@ -87,40 +84,35 @@ impl MiddleAges {
             if settings.middle_ages_defeat_claustrophobia
                 && scenario_progress.current == 360
                 && duration_frames_value.current == 180
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "middle_ages_defeat_claustrophobia")
             }
             if settings.middle_ages_defeat_scotophobia
                 && scenario_progress.current == 370
                 && duration_frames_value.current == 180
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "middle_ages_defeat_scotophobia")
             }
             if settings.middle_ages_defeat_acrophobia
                 && scenario_progress.current == 380
                 && duration_frames_value.current == 180
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "middle_ages_defeat_acrophobia")
             }
             if settings.middle_ages_defeat_hygrophobia
                 && scenario_progress.current == 390
                 && duration_frames_value.current == 180
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "middle_ages_defeat_hygrophobia")
             }
             if settings.middle_ages_defeat_streibough
                 && scenario_progress.current == 420
                 && duration_frames_value.current == 360
-                && frame_pointer_value.old != 0
-                && frame_pointer_value.current < 60
+                && duration_frames_value.old == 0
             {
                 split(splits, "middle_ages_defeat_streibough")
             }

--- a/src/scenario_progress/middle_ages.rs
+++ b/src/scenario_progress/middle_ages.rs
@@ -14,6 +14,8 @@ impl MiddleAges {
         scenario_progress: &Pair<u16>,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
+        frame_pointer_value: &Pair<u32>,
+        duration_frames_value: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_middle_ages
@@ -30,15 +32,37 @@ impl MiddleAges {
             {
                 split(splits, "middle_ages_streibough_joins")
             }
-            if settings.middle_ages_brion
-                && scenario_progress.current == 140
-                && scenario_progress.old < 140
+            if settings.middle_ages_hasshe_house_1
+                && scenario_progress.current == 100
+                && scenario_progress.old < 100
             {
-                split(splits, "middle_ages_brion")
+                split(splits, "middle_ages_hasshe_house_1")
+            }
+            if settings.middle_ages_uranus_joins
+                && scenario_progress.current == 110
+                && scenario_progress.old < 110
+            {
+                split(splits, "middle_ages_uranus_joins")
+            }
+            if settings.middle_ages_hasshe_joins
+                && scenario_progress.current == 130
+                && scenario_progress.old < 130
+            {
+                split(splits, "middle_ages_hasshe_joins")
+            }
+            if settings.middle_ages_archons_roost_1
+                && scenario_progress.current == 150
+                && duration_frames_value.current == 122
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "middle_ages_archons_roost_1")
             }
             if settings.middle_ages_defeat_lord_of_dark
-                && scenario_progress.current == 160
-                && scenario_progress.old < 160
+                && scenario_progress.current == 150
+                && duration_frames_value.current == 347
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
             {
                 split(splits, "middle_ages_defeat_lord_of_dark")
             }
@@ -48,6 +72,12 @@ impl MiddleAges {
             {
                 split(splits, "middle_ages_banished")
             }
+            if settings.middle_ages_arrested
+                && scenario_progress.current == 270
+                && scenario_progress.old < 270
+            {
+                split(splits, "middle_ages_arrested")
+            }
             if settings.middle_ages_prison_escape
                 && scenario_progress.current == 360
                 && scenario_progress.old < 360
@@ -55,20 +85,42 @@ impl MiddleAges {
                 split(splits, "middle_ages_prison_escape")
             }
             if settings.middle_ages_defeat_claustrophobia
-                && scenario_progress.current == 370
-                && scenario_progress.old < 370
+                && scenario_progress.current == 360
+                && duration_frames_value.current == 180
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
             {
                 split(splits, "middle_ages_defeat_claustrophobia")
             }
+            if settings.middle_ages_defeat_scotophobia
+                && scenario_progress.current == 370
+                && duration_frames_value.current == 180
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "middle_ages_defeat_scotophobia")
+            }
+            if settings.middle_ages_defeat_acrophobia
+                && scenario_progress.current == 380
+                && duration_frames_value.current == 180
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
+            {
+                split(splits, "middle_ages_defeat_acrophobia")
+            }
             if settings.middle_ages_defeat_hygrophobia
-                && scenario_progress.current == 395
-                && scenario_progress.old < 395
+                && scenario_progress.current == 390
+                && duration_frames_value.current == 180
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
             {
                 split(splits, "middle_ages_defeat_hygrophobia")
             }
             if settings.middle_ages_defeat_streibough
-                && scenario_progress.current == 430
-                && scenario_progress.old < 430
+                && scenario_progress.current == 420
+                && duration_frames_value.current == 360
+                && frame_pointer_value.old != 0
+                && frame_pointer_value.current < 60
             {
                 split(splits, "middle_ages_defeat_streibough")
             }

--- a/src/scenario_progress/present_day.rs
+++ b/src/scenario_progress/present_day.rs
@@ -14,12 +14,8 @@ impl PresentDay {
         scenario_progress: &Pair<u16>,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
-        namkiat_defeated: &Pair<u8>,
-        aja_defeated: &Pair<u8>,
-        tula_han_defeated: &Pair<u8>,
-        moribe_defeated: &Pair<u8>,
-        max_morgan_defeated: &Pair<u8>,
-        jackie_defeated: &Pair<u8>,
+        martial_artists_defeated: (u8, u8),
+        duration_frames_value: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_present_day
@@ -29,47 +25,47 @@ impl PresentDay {
             split(splits, "start_present_day")
         }
         if current_chapter.current == Chapter::PresentDay as u8 {
-            if settings.present_day_moribe_defeated
-                && moribe_defeated.old == 0
-                && moribe_defeated.current == 1
+            if settings.present_day_defeated_1
+                && martial_artists_defeated.1 == 0
+                && martial_artists_defeated.0 == 1
             {
-                split(splits, "present_day_moribe_defeated_split")
+                split(splits, "present_day_defeated_1")
             }
-            if settings.present_day_max_morgan_defeated
-                && max_morgan_defeated.old == 0
-                && max_morgan_defeated.current == 1
+            if settings.present_day_defeated_2
+                && martial_artists_defeated.1 == 1
+                && martial_artists_defeated.0 == 2
             {
-                split(splits, "present_day_max_morgan_defeated_split")
+                split(splits, "present_day_defeated_2")
             }
-            if settings.present_day_jackie_defeated
-                && jackie_defeated.old == 0
-                && jackie_defeated.current == 1
+            if settings.present_day_defeated_3
+                && martial_artists_defeated.1 == 2
+                && martial_artists_defeated.0 == 3
             {
-                split(splits, "present_day_jackie_defeated_split")
+                split(splits, "present_day_defeated_3")
             }
-            if settings.present_day_namkiat_defeated
-                && namkiat_defeated.old == 0
-                && namkiat_defeated.current == 1
+            if settings.present_day_defeated_4
+                && martial_artists_defeated.1 == 3
+                && martial_artists_defeated.0 == 4
             {
-                split(splits, "present_day_namkiat_defeated_split")
+                split(splits, "present_day_defeated_4")
             }
-            if settings.present_day_aja_defeated
-                && aja_defeated.old == 0
-                && aja_defeated.current == 1
+            if settings.present_day_defeated_5
+                && martial_artists_defeated.1 == 4
+                && martial_artists_defeated.0 == 5
             {
-                split(splits, "present_day_aja_defeated_split")
+                split(splits, "present_day_defeated_5")
             }
-            if settings.present_day_tula_han_defeated
-                && tula_han_defeated.old == 0
-                && tula_han_defeated.current == 1
+            if settings.present_day_defeated_all
+                && martial_artists_defeated.1 == 5
+                && martial_artists_defeated.0 == 6
             {
-                split(splits, "present_day_tula_han_defeated_split")
+                split(splits, "present_day_defeated_all")
             }
-            if settings.present_day_start_odie
-                && map_id.old == 10228626
-                && map_id.current == 10228592
+            if settings.present_day_defeat_odie
+                && duration_frames_value.current == 360
+                && duration_frames_value.old == 0
             {
-                split(splits, "present_day_start_odie_split")
+                split(splits, "present_day_defeat_odie")
             }
             if settings.present_day_end_split
                 && scenario_progress.current == 0

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -169,16 +169,28 @@ pub struct Settings {
     middle_ages: Title,
     /// Middle Ages - Exit Castle Town
     pub middle_ages_streibough_joins: bool,
-    /// Middle Ages - Hasshe picks up Brion
-    pub middle_ages_brion: bool,
+    /// Middle Ages - Visit Hasshe
+    pub middle_ages_hasshe_house_1: bool,
+    /// Middle Ages - Uranus Joins
+    pub middle_ages_uranus_joins: bool,
+    /// Middle Ages - Hasshe Joins
+    pub middle_ages_hasshe_joins: bool,
+    /// Middle Ages - Confront The Lord of Dark
+    pub middle_ages_archons_roost_1: bool,
     /// Middle Ages - Defeat The Lord of Dark
     pub middle_ages_defeat_lord_of_dark: bool,
     /// Middle Ages - Banished from Lucrece
     pub middle_ages_banished: bool,
+    /// Middle Ages - Arrested
+    pub middle_ages_arrested: bool,
     /// Middle Ages - Prison Escape
     pub middle_ages_prison_escape: bool,
     /// Middle Ages - Defeat Claustrophobia
     pub middle_ages_defeat_claustrophobia: bool,
+    /// Middle Ages - Defeat Scotophobia
+    pub middle_ages_defeat_scotophobia: bool,
+    /// Middle Ages - Defeat Acrophobia
+    pub middle_ages_defeat_acrophobia: bool,
     /// Middle Ages - Defeat Hygrophobia
     pub middle_ages_defeat_hygrophobia: bool,
     /// Middle Ages - Defeat Streibough
@@ -196,7 +208,9 @@ pub struct Settings {
     /// Dominion of Hate - Defeat Odio Face
     pub dominion_defeat_odio_face: bool,
     ///Dominion of Hate - Defeat Pure Odio
-    pub dominion_defeat_odio: bool,
+    pub dominion_defeat_pure_odio: bool,
+    ///Dominion of Hate - Complete Odio Fight (fade back to cutscene)
+    pub dominion_defeat_odio_fade: bool,
     /// Dominion of Hate - Enter Sin Odio
     pub dominion_enter_sin_fight: bool,
     /// Dominion of Hate - End Sin Odio Phase 1

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -85,22 +85,20 @@ pub struct Settings {
     pub twilight_end_split: bool,
 
     present_day: Title,
-    #[heading_level = 2]
-    last_fight_before_odie_will_not_trigger: Title,
-    // Present Day - Moribe Defeated
-    pub present_day_moribe_defeated: bool,
-    // Present Day - Max Morgan Defeated
-    pub present_day_max_morgan_defeated: bool,
-    // Present Day - Jackie Defeated
-    pub present_day_jackie_defeated: bool,
-    // Present Day - Namkiat Defeated
-    pub present_day_namkiat_defeated: bool,
-    // Present Day - Aja Defeated
-    pub present_day_aja_defeated: bool,
-    // Present Day - Tula Han Defeated
-    pub present_day_tula_han_defeated: bool,
-    // Present Day - Start Odie Fight
-    pub present_day_start_odie: bool,
+    // Present Day - Defeat 1 martial artist
+    pub present_day_defeated_1: bool,
+    // Present Day - Defeat 2 martial artists
+    pub present_day_defeated_2: bool,
+    // Present Day - Defeat 3 martial artists
+    pub present_day_defeated_3: bool,
+    // Present Day - Defeat 4 martial artists
+    pub present_day_defeated_4: bool,
+    // Present Day - Defeat 5 martial artists
+    pub present_day_defeated_5: bool,
+    // Present Day - Defeat all martial artists
+    pub present_day_defeated_all: bool,
+    // Present Day - Defeat Odie
+    pub present_day_defeat_odie: bool,
     // Present Day - Chapter Complete
     pub present_day_end_split: bool,
 


### PR DESCRIPTION
Added the following splits:
-leave Hasshe's house after examining his shield
-Uranus joins the party
-Hasshe joins the party (replaces previous Brion split)
-start the Lord of Dark fight
-get arrested
-defeat Scotophobia
-defeat Acrophobia

I have also changed the splits for defeating The Lord of Dark, Claustrophobia, Hygrophobia, and Streibough to use their defeat animations instead of only splitting after returning to the overworld. This method is also used for the new Scotophobia and Acrophobia splits.
In the Dominion of Hate, I divided the split for defeating Odio into two different splits - Pure Odio's defeat animation (new), and the scenario progress update after fading out of the fight (old). The scenario progress update split risks splitting on game over due to Armageddon, and is mostly included in case someone wants to do a route involving Pure Odio Skip.