### PR TITLE
Added splits for the remaining endings in Dominion of Hate, and adjusted Sad Ending split to match them

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,7 @@ async fn main() {
                                 &current_chapter,
                                 &scenario_progress,
                                 &map_id,
+                                &transition_state,
                                 &frame_pointer_value,
                                 &duration_frames_value,
                             );

--- a/src/scenario_progress/dominion_of_hate.rs
+++ b/src/scenario_progress/dominion_of_hate.rs
@@ -12,7 +12,8 @@ impl DominionOfHate {
         splits: &mut HashSet<String>,
         current_chapter: &Pair<u8>,
         scenario_progress: &Pair<u16>,
-        _map_id: &Pair<u32>,
+        map_id: &Pair<u32>,
+        transition_state: &Pair<u32>,
         frame_pointer_value: &Pair<u32>,
         duration_frames_value: &Pair<u32>,
     ) {
@@ -64,6 +65,22 @@ impl DominionOfHate {
             {
                 split(splits, "dominion_defeat_odio_fade")
             }
+            if settings.dominion_never_end
+                && scenario_progress.current == 80
+                && map_id.current == 0
+                && transition_state.old == 4
+                && transition_state.current == 0
+            {
+                split(splits, "dominion_never_end")
+            }
+            if settings.dominion_incomplete_destiny
+                && scenario_progress.current == 110
+                && map_id.current == 0
+                && transition_state.old == 4
+                && transition_state.current == 0
+            {
+                split(splits, "dominion_incomplete_destiny")
+            }
             if settings.dominion_enter_sin_fight
                 && scenario_progress.current == 110
                 && duration_frames_value.current == 270
@@ -106,11 +123,13 @@ impl DominionOfHate {
             {
                 split(splits, "dominion_oersted_armageddon")
             }
-            if settings.dominion_oersted_get_revenge 
-                && scenario_progress.current == 1020
-                && scenario_progress.old < 1020
+            if settings.dominion_oersted_sad_ending 
+                && scenario_progress.current == 1130
+                && map_id.current == 0
+                && transition_state.old == 4
+                && transition_state.current == 0
             {
-                split(splits, "dominion_oersted_get_revenge")
+                split(splits, "dominion_oersted_sad_ending")
             } 
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -217,6 +217,10 @@ pub struct Settings {
     pub dominion_defeat_pure_odio: bool,
     ///Dominion of Hate - Complete Odio Fight (fade back to cutscene)
     pub dominion_defeat_odio_fade: bool,
+    /// Dominion of Hate - Complete Never Ending
+    pub dominion_never_end: bool,
+    /// Dominion of Hate - Complete Good Ending (not Best Ending)
+    pub dominion_incomplete_destiny: bool,
     /// Dominion of Hate - Enter Sin Odio
     pub dominion_enter_sin_fight: bool,
     /// Dominion of Hate - End Sin Odio Phase 1
@@ -229,7 +233,7 @@ pub struct Settings {
     /// Dominion of Hate (Oersted) - Split on defeating Steel Titan
     pub dominion_oersted_defeat_steel_titan: bool,
     /// Dominion of Hate (Oersted) - Split on Sad Ending
-    pub dominion_oersted_get_revenge: bool,
+    pub dominion_oersted_sad_ending: bool,
     /// Dominion of Hate (Oersted) - Split on Armageddon Ending
     pub dominion_oersted_armageddon: bool,
 }


### PR DESCRIPTION
Added splits for Never Ending and Good (not Best) Ending. I was only able to detect these endings on the "save completion data" prompt so I decided to also change the Sad Ending split, which I previously detected through the first of the ending cutscenes, to also be on that screen, leaving Best Ending and Armageddon Ending as the only endings where the split is earlier than that