### PR TITLE
Added Inko and Gamahebi splits, changed as many existing boss splits as possible to use defeat animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,14 @@ A multiplatform autosplitter for Live a Live (PC)
 # TODO:
 - [~] Character Story Splits
    - partially done in `revamp` branch, going through to get scenario ids
-- [ ] Full game ending splits
+- [x] Full game ending splits
     - [x] True Ending - Sin Odio end flash (this is the main and currently only official speedrun category)
-    - [ ] Incomplete Destiny Ending - cutscene after completing partial boss rush
-    - [ ] Never Ending - defeat Oersted? save prompt after completion? (a change in Scenario Progress after defeating Oersted is not guaranteed, particularly in the context of multi-ending runs like All Achievements)
+    - [x] Incomplete Destiny Ending - cutscene after completing partial boss rush
+    - [x] Never Ending - defeat Oersted? save prompt after completion? (a change in Scenario Progress after defeating Oersted is not guaranteed, particularly in the context of multi-ending runs like All Achievements)
     - [x] Sad Ending - skip cutscene after defeating all protagonists
     - [x] Armageddon (in Oersted route) - animation of activating the Armageddon action
-- [ ] TODO: Determine a better way to handle Present Day defeated enemies.
-  - intVars + in controller Face icons dont work for last enemy (since the game does this intentionally so you can reload the save)
-  - Maybe add a collective split when the odie kill animation starts.
-  - [ ] map id change for starting odie.
+- [x] Determine a better way to handle Present Day defeated enemies.
+  - counting boss defeat animations
 
 ## Install
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,7 @@ async fn main() {
                                 &scenario_progress,
                                 &map_id,
                                 &transition_state,
+                                &duration_frames_value,
                             );
 
                             scenario_progress::distant_future::DistantFuture::maybe_split(
@@ -265,6 +266,7 @@ async fn main() {
                                 &scenario_progress,
                                 &map_id,
                                 &transition_state,
+                                &duration_frames_value,
                             );
                             
                             scenario_progress::wild_west::WildWest::maybe_split(
@@ -274,6 +276,7 @@ async fn main() {
                                 &scenario_progress,
                                 &map_id,
                                 &transition_state,
+                                &duration_frames_value,
                             );
                             scenario_progress::present_day::PresentDay::maybe_split(
                                 &settings,
@@ -293,6 +296,7 @@ async fn main() {
                                 &scenario_progress,
                                 &map_id,
                                 &transition_state,
+                                &duration_frames_value,
                             );
 
                             scenario_progress::twilight_of_edo_japan::TwilightOfEdoJapan::maybe_split(
@@ -303,6 +307,7 @@ async fn main() {
                                 &chapter_data,
                                 &map_id,
                                 &transition_state,
+                                &duration_frames_value,
                             );
 
                             scenario_progress::middle_ages::MiddleAges::maybe_split(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ async fn main() {
         // asr::print_message("UPDATING");
         process
             .until_closes(async {
-                let mut martial_artists_defeated = (0u8, 0u8);
+                let mut bosses_defeated = (0u8, 0u8);
                 loop {
                     settings.update();
 
@@ -190,14 +190,40 @@ async fn main() {
 
                     chapter_data.update(&process, main_module_base);
 
-                    if current_chapter.current == Chapter::PresentDay as u8 {
-                        if duration_frames_value.current == 180 &&
-                            duration_frames_value.old == 0 
+                    if current_chapter.current == Chapter::ImperialChina as u8 {
+                        if scenario_progress.current >= 521
+                            && scenario_progress.current < 531 //only run the following checks if you are in the gauntlet (and before Yi Pei Kou)
                         {
-                            martial_artists_defeated.1 = martial_artists_defeated.0;
-                            martial_artists_defeated.0 += 1u8;
+                            if scenario_progress.old <= 520 //set counter to 0 at the start of the gauntlet
+                            {
+                                bosses_defeated.1 = bosses_defeated.0;
+                                bosses_defeated.0 = 0u8;
+                            }
+                            if duration_frames_value.current == 180
+                                && duration_frames_value.old == 0 
+                            {
+                                bosses_defeated.1 = bosses_defeated.0;
+                                bosses_defeated.0 += 1u8;
+                            } 
+                            if (duration_frames_value.current == 200
+                                && duration_frames_value.old == 0) //resets count on game over
+                                || scenario_progress.current > scenario_progress.old //resets count between fights
+                            {
+                                bosses_defeated.1 = bosses_defeated.0;
+                                bosses_defeated.0 = 0u8;
+                            }
                         }
-                        timer::set_variable_int("Martial artists defeated", martial_artists_defeated.0)
+                        timer::set_variable_int("Boss defeat animations", bosses_defeated.0)
+                    }
+
+                    if current_chapter.current == Chapter::PresentDay as u8 {
+                        if duration_frames_value.current == 180
+                            && duration_frames_value.old == 0 
+                        {
+                            bosses_defeated.1 = bosses_defeated.0;
+                            bosses_defeated.0 += 1u8;
+                        }
+                        timer::set_variable_int("Martial artists defeated", bosses_defeated.0)
                     }
 
                     // #[cfg(debug_assertions)]
@@ -221,7 +247,7 @@ async fn main() {
                                 && current_chapter.current != Chapter::Menu as u8
                             {
                                 // asr::print_message("Clearing Splits and Starting");
-                                martial_artists_defeated = (0u8,0u8);
+                                bosses_defeated = (0u8, 0u8);
                                 splits = HashSet::<String>::new();
                                 timer::start();
                             }
@@ -231,7 +257,7 @@ async fn main() {
                                 && new_game_start.current > 0
                             {
                                 // asr::print_message("Clearing Splits and Starting");
-                                martial_artists_defeated = (0u8,0u8);
+                                bosses_defeated = (0u8, 0u8);
                                 splits = HashSet::<String>::new();
                                 timer::start();
                             }
@@ -266,6 +292,7 @@ async fn main() {
                                 &scenario_progress,
                                 &map_id,
                                 &transition_state,
+                                bosses_defeated,
                                 &duration_frames_value,
                             );
                             
@@ -285,7 +312,7 @@ async fn main() {
                                 &scenario_progress,
                                 &map_id,
                                 &transition_state,
-                                martial_artists_defeated,
+                                bosses_defeated,
                                 &duration_frames_value,
                             );
     

--- a/src/scenario_progress/dominion_of_hate.rs
+++ b/src/scenario_progress/dominion_of_hate.rs
@@ -14,6 +14,7 @@ impl DominionOfHate {
         scenario_progress: &Pair<u16>,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
+        bosses_defeated: (u8, u8),
         frame_pointer_value: &Pair<u32>,
         duration_frames_value: &Pair<u32>,
     ) {
@@ -59,11 +60,12 @@ impl DominionOfHate {
             {
                 split(splits, "dominion_defeat_pure_odio")
             }
-            if settings.dominion_defeat_odio_fade
-                && scenario_progress.old < 70
-                && scenario_progress.current == 70
+            if settings.dominion_pure_odio_skip
+                && scenario_progress.current == 60
+                && bosses_defeated.0 == 4
+                && bosses_defeated.1 < 4
             {
-                split(splits, "dominion_defeat_odio_fade")
+                split(splits, "dominion_pure_odio_skip")
             }
             if settings.dominion_never_end
                 && scenario_progress.current == 80

--- a/src/scenario_progress/imperial_china.rs
+++ b/src/scenario_progress/imperial_china.rs
@@ -14,6 +14,7 @@ impl ImperialChina {
         scenario_progress: &Pair<u16>,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
+        bosses_defeated: (u8, u8),
         duration_frames_value: &Pair<u32>,
     ) {
         // Start Split
@@ -69,37 +70,37 @@ impl ImperialChina {
                 split(splits, "imperial_china_defeat_table_guards")
             }
             if settings.imperial_china_defeat_su_xi_san_xi
-                && scenario_progress.old >= 521
-                && scenario_progress.old < 522
-                && scenario_progress.current == 522
+                && scenario_progress.current == 521
+                && bosses_defeated.0 == 2
+                && bosses_defeated.1 < 2
             {
                 split(splits, "imperial_china_defeat_su_xi_san_xi")
             }
             if settings.imperial_china_defeat_yi_xi_er_xi
-                && scenario_progress.old >= 522
-                && scenario_progress.old < 523
-                && scenario_progress.current == 523
+                && scenario_progress.current == 522
+                && bosses_defeated.0 == 2
+                && bosses_defeated.1 < 2
             {
                 split(splits, "imperial_china_defeat_yi_xi_er_xi")
             }
             if settings.imperial_china_defeat_tong_cha_sha_cha
-                && scenario_progress.old >= 523
-                && scenario_progress.old < 524
-                && scenario_progress.current == 524
+                && scenario_progress.current == 523
+                && bosses_defeated.0 == 2
+                && bosses_defeated.1 < 2
             {
                 split(splits, "imperial_china_defeat_tong_cha_sha_cha")
             }
             if settings.imperial_china_defeat_pei_cha_nan_cha
-                && scenario_progress.old >= 524
-                && scenario_progress.old < 530
-                && scenario_progress.current == 530
+                && scenario_progress.current == 524
+                && bosses_defeated.0 == 2
+                && bosses_defeated.1 < 2
             {
                 split(splits, "imperial_china_defeat_pei_cha_nan_cha")
             }
             if settings.imperial_china_defeat_xian_lin_chan
-                && scenario_progress.old >= 530
-                && scenario_progress.old < 531
-                && scenario_progress.current == 531
+                && scenario_progress.current == 530
+                && bosses_defeated.0 == 3
+                && bosses_defeated.1 < 3
             {
                 split(splits, "imperial_china_defeat_xian_lin_chan")
             }

--- a/src/scenario_progress/imperial_china.rs
+++ b/src/scenario_progress/imperial_china.rs
@@ -14,6 +14,7 @@ impl ImperialChina {
         scenario_progress: &Pair<u16>,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
+        duration_frames_value: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_imperial_china
@@ -103,18 +104,18 @@ impl ImperialChina {
                 split(splits, "imperial_china_defeat_xian_lin_chan")
             }
             if settings.imperial_china_defeat_yi_pei_kou
-                && scenario_progress.old >= 531
-                && scenario_progress.old < 532
-                && scenario_progress.current == 532
+                && scenario_progress.current == 531
+                && duration_frames_value.current == 180
+                && duration_frames_value.old == 0
             {
                 split(splits, "imperial_china_defeat_yi_pei_kou")
             }
             if settings.imperial_china_defeat_ou_di_wan_li
-                && scenario_progress.old >= 533
-                && scenario_progress.old < 550
-                && scenario_progress.current == 550
+                && scenario_progress.current >= 532
+                && duration_frames_value.current == 360
+                && duration_frames_value.old == 0
             {
-                split(splits, "imperial_china_defeat_yi_pei_kou")
+                split(splits, "imperial_china_defeat_ou_di_wan_lee")
             }
             if settings.imperial_china_end_split
                 && scenario_progress.current == 650

--- a/src/scenario_progress/near_future.rs
+++ b/src/scenario_progress/near_future.rs
@@ -14,6 +14,7 @@ impl NearFuture {
         scenario_progress: &Pair<u16>,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
+        duration_frames_value: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_near_future
@@ -66,6 +67,20 @@ impl NearFuture {
                 && scenario_progress.current == 746
             {
                 split(splits, "near_future_enter_titan_2")
+            }
+            if settings.near_future_enter_inko_fight
+                && scenario_progress.current == 760
+                && duration_frames_value.current == 122
+                && duration_frames_value.old == 0
+            {
+                split(splits, "near_future_enter_inko_fight")
+            }
+            if settings.near_future_defeat_inko
+                && scenario_progress.current == 760
+                && duration_frames_value.current == 360
+                && duration_frames_value.old == 0
+            {
+                split(splits, "near_future_defeat_inko")
             }
             if settings.near_future_end_split
                 && scenario_progress.current == 900

--- a/src/scenario_progress/prehistory.rs
+++ b/src/scenario_progress/prehistory.rs
@@ -14,6 +14,7 @@ impl Prehistory {
         scenario_progress: &Pair<u16>,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
+        duration_frames_value: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_prehistory
@@ -59,9 +60,9 @@ impl Prehistory {
                 split(splits, "prehistory_defeat_zaki_3")
             }
             if settings.prehistory_defeat_odo
-                && scenario_progress.old >= 405
-                && scenario_progress.old < 410
-                && scenario_progress.current == 410
+                && scenario_progress.current == 405
+                && duration_frames_value.current == 360
+                && duration_frames_value.old == 0
             {
                 split(splits, "prehistory_defeat_odo")
             }

--- a/src/scenario_progress/twilight_of_edo_japan.rs
+++ b/src/scenario_progress/twilight_of_edo_japan.rs
@@ -20,6 +20,7 @@ impl TwilightOfEdoJapan {
         chapter_data: &ChapterData,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
+        duration_frames_value: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_twilight_of_edo_japan
@@ -30,24 +31,16 @@ impl TwilightOfEdoJapan {
         }
         if current_chapter.current == Chapter::TwilightOfEdoJapan as u8 {
             // Put Scenario Splits Here
-            if settings.twilight_dodge_attic_ninja
+            if settings.twilight_attic_ninja_appears
                 && scenario_progress.old >= 70
                 && scenario_progress.old < 80
                 && scenario_progress.current == 80
             {
-                split(splits, "twilight_dodge_attic_ninja")
-            }
-
-            if settings.twilight_defeat_gennai
-                && scenario_progress.old >= 80
-                && scenario_progress.old < 120
-                && scenario_progress.current == 120
-            {
-                split(splits, "twilight_defeat_gennai")
+                split(splits, "twilight_attic_ninja_appears")
             }
 
             if settings.twilight_level_5_storehouse_leave
-                && map_id.old - map_id.current == 400 
+                && map_id.old - map_id.current == 400
                 && chapter_data
                     .character_data
                     .clone()
@@ -81,6 +74,14 @@ impl TwilightOfEdoJapan {
                 split(splits, "twilight_level_6_storehouse_leave")
             }
 
+            if settings.twilight_defeat_gennai
+                && scenario_progress.old >= 80
+                && scenario_progress.old < 120
+                && scenario_progress.current == 120
+            {
+                split(splits, "twilight_defeat_gennai")
+            }
+
             if settings.twilight_defeat_monks
                 && scenario_progress.old >= 130
                 && scenario_progress.old < 160
@@ -90,27 +91,35 @@ impl TwilightOfEdoJapan {
             }
 
             if settings.twilight_defeat_musashi
-                && scenario_progress.old >= 160
-                && scenario_progress.old < 170
-                && scenario_progress.current == 170
+                && scenario_progress.current == 160
+                && duration_frames_value.current == 180
+                && duration_frames_value.old == 0
             {
                 split(splits, "twilight_defeat_musashi")
             }
 
             if settings.twilight_defeat_yodogimi
-                && scenario_progress.old >= 180
-                && scenario_progress.old < 190
-                && scenario_progress.current == 190
+                && scenario_progress.current == 180
+                && duration_frames_value.current == 180
+                && duration_frames_value.old == 0
             {
                 split(splits, "twilight_defeat_yodogimi")
             }
 
             if settings.twilight_defeat_ode_iou
-                && scenario_progress.old >= 190
-                && scenario_progress.old < 200
-                && scenario_progress.current == 200
+                && scenario_progress.current == 190
+                && duration_frames_value.current == 180
+                && duration_frames_value.old == 0
             {
                 split(splits, "twilight_defeat_ode_iou")
+            }
+
+            if settings.twilight_defeat_gamahebi
+                && scenario_progress.current == 210
+                && duration_frames_value.current == 360
+                && duration_frames_value.old == 0
+            {
+                split(splits, "twilight_defeat_gamahebi")
             }
 
             if settings.twilight_end_split

--- a/src/scenario_progress/wild_west.rs
+++ b/src/scenario_progress/wild_west.rs
@@ -14,6 +14,7 @@ impl WildWest {
         scenario_progress: &Pair<u16>,
         map_id: &Pair<u32>,
         transition_state: &Pair<u32>,
+        duration_frames_value: &Pair<u32>,
     ) {
         // Start Split
         if settings.start_wild_west
@@ -49,8 +50,9 @@ impl WildWest {
                 split(splits, "wild_west_end_ambush_phase_split")
             }
             if settings.wild_west_defeat_odie
-                && scenario_progress.old == 200
-                && scenario_progress.current == 210
+                && scenario_progress.current == 200
+                && duration_frames_value.current == 360
+                && duration_frames_value.old == 0
             {
                 split(splits, "wild_west_defeat_odie")
             }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -61,7 +61,11 @@ pub struct Settings {
     pub near_future_robot: bool,
     /// Near Future - Enter Steel Titan 2
     pub near_future_enter_titan_2: bool,
-    // Near Future - Chapter Complete
+    /// Near Future - Enter Great Inko Fight
+    pub near_future_enter_inko_fight: bool,
+    /// Near Future - Defeat The Great Inko
+    pub near_future_defeat_inko: bool,
+    /// Near Future - Chapter Complete
     pub near_future_end_split: bool,
     
     distant_future: Title,
@@ -73,8 +77,8 @@ pub struct Settings {
     pub distant_future_end_split: bool,
 
     twilight_of_edo_japan: Title,
-    /// Edo Japan - After Dodging Attic Ninja
-    pub twilight_dodge_attic_ninja: bool,
+    /// Edo Japan - After Attic Ninja Appears
+    pub twilight_attic_ninja_appears: bool,
     /// Edo Japan - Level 5 (>=56xp) Storehouse Leave
     pub twilight_level_5_storehouse_leave: bool,
     /// Edo Japan - OR: Level 6 Storehouse Leave
@@ -89,6 +93,8 @@ pub struct Settings {
     pub twilight_defeat_yodogimi: bool,
     /// Edo Japan - Defeat Ode Iou (Human Form)
     pub twilight_defeat_ode_iou: bool,
+    /// Edo Japan - Defeat Ode Iou (Gamahebi Transformation)
+    pub twilight_defeat_gamahebi: bool,
     // Edo Japan - Chapter Complete
     pub twilight_end_split: bool,
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -221,8 +221,8 @@ pub struct Settings {
     pub dominion_defeat_odio_face: bool,
     ///Dominion of Hate - Defeat Pure Odio
     pub dominion_defeat_pure_odio: bool,
-    ///Dominion of Hate - Complete Odio Fight (fade back to cutscene)
-    pub dominion_defeat_odio_fade: bool,
+    ///Dominion of Hate - Perform Pure Odio Skip (kill all 4 face pieces)
+    pub dominion_pure_odio_skip: bool,
     /// Dominion of Hate - Complete Never Ending
     pub dominion_never_end: bool,
     /// Dominion of Hate - Complete Good Ending (not Best Ending)


### PR DESCRIPTION
The following bosses still aren't based on defeat animations:
-Zaki, because he doesn't have a defeat animation
-Gennai, because he and Shiro are fought on the same Scenario Progress Value, which could cause issues for Geno runs
-Sun Tzu Wang, because the fight has non-breakdown regular enemies
-Imperial China gauntlet bosses except for Yi Pei Kou, since there are multiple boss defeat animations per fight there (it would be possible to make them work by counting the animations like in the Present Day splits)